### PR TITLE
Add reputation-based credit airdrop for new users

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -103,7 +103,13 @@ async def validate_github_token(token: str) -> dict:
     if resp.status_code != 200:
         raise ValueError(f"github_api_error:{resp.status_code}")
     data = resp.json()
-    return {"id": data["id"], "login": data["login"]}
+    return {
+        "id": data["id"],
+        "login": data["login"],
+        "created_at": data.get("created_at", ""),
+        "public_repos": data.get("public_repos", 0),
+        "followers": data.get("followers", 0),
+    }
 
 
 async def start_device_flow(client_id: str) -> dict:

--- a/core/reputation.py
+++ b/core/reputation.py
@@ -1,0 +1,36 @@
+"""
+Reputation-based credit calculation.
+
+Maps GitHub profile data to initial credit allocation (100–5000 range).
+All data comes from the GitHub GET /user response — no extra API calls needed.
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+
+def calculate_credits(created_at: str, public_repos: int,
+                      followers: int) -> Decimal:
+    """
+    Calculate initial credits based on GitHub reputation signals.
+
+    Args:
+        created_at: ISO 8601 timestamp of GitHub account creation.
+        public_repos: Number of public repositories.
+        followers: Number of followers.
+
+    Returns:
+        Credit amount as Decimal, in range [100, 5000].
+    """
+    now = datetime.now(timezone.utc)
+    created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    account_age_years = (now - created).days / 365.25
+
+    score = (
+        min(account_age_years, 10) * 20       # 0–200 pts for age (10yr cap)
+        + min(public_repos, 100) * 1           # 0–100 pts for repos (100 cap)
+        + min(followers, 500) * 0.4            # 0–200 pts for followers (500 cap)
+    )
+    # score range: 0–500, credit range: 100–5000
+    credits = 100 + score * 9.8
+    return Decimal(str(round(credits)))


### PR DESCRIPTION
## Summary
- New `core/reputation.py` — pure `calculate_credits()` function mapping GitHub profile to 100–5000 credits
- Formula: account age (0–200 pts) + public repos (0–100 pts) + followers (0–200 pts) → score 0–500 → credits 100–5000
- `core/auth.py` now extracts `created_at`, `public_repos`, `followers` from existing `GET /user` response (no extra API calls)
- Both auth endpoints (`auth_github`, `auth_device_poll`) use reputation credits for new users instead of flat `INITIAL_CREDITS`
- Existing users keep their current balance on re-auth (no double airdrop)
- 8 new tests covering the formula edge cases and auth integration

| Profile | Age | Repos | Followers | Credits |
|---------|-----|-------|-----------|---------|
| Brand new bot | 0 | 0 | 0 | **100** |
| New dev (6mo) | 0.5 | 3 | 1 | **~200** |
| Active dev (3yr) | 3 | 30 | 15 | **~900** |
| Senior dev (7yr) | 7 | 60 | 100 | **~2000** |
| Open source veteran | 10+ | 100+ | 500+ | **5000** |

## Test plan
- [ ] `pytest core/test_api.py` — all 56 tests pass (48 existing + 8 new)
- [ ] `pytest core/test_core.py` — all 37 core tests still pass
- [ ] New account with brand-new GitHub profile gets 100 credits
- [ ] Veteran account gets 5000 credits
- [ ] Re-auth same user → balance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)