### PR TITLE
Add webhook receiver for external repo PR markets

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -3,12 +3,17 @@ FastAPI application. Agents-first HTTP API for the futarchy prediction market.
 
 Public endpoints (no auth): health, markets, market detail, positions, trades.
 User endpoints (API key): /me, buy, sell.
-Admin endpoints (admin key): mint, create market, resolve, void.
+Admin endpoints (admin key): mint, create market, resolve, void, tracked repos.
+Webhook: POST /v1/hooks/github — receive GitHub PR events for tracked repos.
 """
 
 import asyncio
+import hashlib
+import hmac
+import logging
 import os
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone, timedelta
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
@@ -30,6 +35,7 @@ from core.api_models import (
     ResolveRequest, HealthResponse,
     AddLiquidityRequest, AddLiquidityResponse,
     UpdateMetadataRequest,
+    AddRepoRequest, TrackedRepoResponse, WebhookResponse,
 )
 from core.auth import (
     AuthStore, validate_github_token,
@@ -38,30 +44,42 @@ from core.auth import (
 from core.lmsr import max_loss, prices as lmsr_prices, cost_to_move_price
 from core.market_engine import MarketEngine
 from core.middleware import AuthUser, AdminDep, require_auth, rate_limiter
-from core.models import ZERO, reset_counters
+from core.models import ZERO, TrackedRepo, reset_counters
 from core.persistence import save_snapshot, load_snapshot
 from core.risk_engine import RiskEngine, InsufficientBalance
+
+logger = logging.getLogger(__name__)
 
 
 STATE_PATH = os.environ.get("FUTARCHY_STATE", "./futarchy_state.json")
 INITIAL_CREDITS = Decimal(os.environ.get("INITIAL_CREDITS", "100"))
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
+TREASURY_ACCOUNT_ID = os.environ.get("FUTARCHY_TREASURY_ID", "")
+
+# Liquidity settings (matching pr-market.yml defaults)
+LIQUIDITY_INITIAL = os.environ.get("LIQUIDITY_INITIAL", "40")
+LIQUIDITY_STEP = os.environ.get("LIQUIDITY_STEP", "40")
+LIQUIDITY_RAMP_STEPS = int(os.environ.get("LIQUIDITY_RAMP_STEPS", "4"))
+LIQUIDITY_RAMP_INTERVAL_MINUTES = int(os.environ.get("LIQUIDITY_RAMP_INTERVAL_MINUTES", "30"))
+LIQUIDITY_BUDGET = os.environ.get("LIQUIDITY_BUDGET", "200")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Load state
     if os.path.exists(STATE_PATH):
-        risk, me, auth_store = load_snapshot(STATE_PATH)
+        risk, me, auth_store, tracked_repos = load_snapshot(STATE_PATH)
     else:
         reset_counters()
         risk = RiskEngine()
         me = MarketEngine(risk)
         auth_store = AuthStore()
+        tracked_repos = {}
 
     app.state.risk = risk
     app.state.me = me
     app.state.auth_store = auth_store or AuthStore()
+    app.state.tracked_repos = tracked_repos
     app.state.lock = asyncio.Lock()
     yield
 
@@ -73,7 +91,8 @@ app.add_exception_handler(APIError, api_error_handler)
 def _save():
     """Save state to disk. Called after every mutation."""
     save_snapshot(app.state.risk, app.state.me, STATE_PATH,
-                  auth_store=app.state.auth_store)
+                  auth_store=app.state.auth_store,
+                  tracked_repos=app.state.tracked_repos)
 
 
 STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
@@ -647,3 +666,222 @@ async def admin_update_metadata(market_id: int, req: UpdateMetadataRequest,
         _save()
 
     return {"market_id": market_id, "metadata": m.metadata}
+
+
+# ---------------------------------------------------------------------------
+# Admin: Tracked Repos
+# ---------------------------------------------------------------------------
+
+@app.get("/v1/admin/repos")
+async def admin_list_repos(_: AdminDep) -> list[TrackedRepoResponse]:
+    """List tracked repos."""
+    return [
+        TrackedRepoResponse(
+            repo=r.repo,
+            enabled=r.enabled,
+            has_webhook_secret=r.webhook_secret is not None,
+            added_at=r.added_at,
+        )
+        for r in app.state.tracked_repos.values()
+    ]
+
+
+@app.post("/v1/admin/repos")
+async def admin_add_repo(req: AddRepoRequest, _: AdminDep) -> TrackedRepoResponse:
+    """Add a tracked repo for webhook-based PR markets."""
+    slug = req.repo.strip().lower()
+    if "/" not in slug or len(slug.split("/")) != 2:
+        raise APIError(400, "invalid_repo",
+                       "Repo must be in 'owner/name' format")
+
+    async with app.state.lock:
+        repo = TrackedRepo.new(
+            repo=slug,
+            webhook_secret=req.webhook_secret,
+            enabled=req.enabled,
+        )
+        app.state.tracked_repos[slug] = repo
+        _save()
+
+    return TrackedRepoResponse(
+        repo=repo.repo,
+        enabled=repo.enabled,
+        has_webhook_secret=repo.webhook_secret is not None,
+        added_at=repo.added_at,
+    )
+
+
+@app.delete("/v1/admin/repos/{repo_slug:path}")
+async def admin_delete_repo(repo_slug: str, _: AdminDep) -> dict:
+    """Remove a tracked repo. Use URL-encoded slug (e.g. snapshot-labs%2Fsx-monorepo)."""
+    slug = repo_slug.strip().lower()
+    async with app.state.lock:
+        if slug not in app.state.tracked_repos:
+            raise APIError(404, "repo_not_found",
+                           f"Repo '{slug}' is not tracked")
+        del app.state.tracked_repos[slug]
+        _save()
+
+    return {"deleted": slug}
+
+
+# ---------------------------------------------------------------------------
+# GitHub Webhook
+# ---------------------------------------------------------------------------
+
+def _verify_webhook_signature(payload: bytes, signature: str,
+                              secret: str) -> bool:
+    """Verify GitHub HMAC-SHA256 webhook signature."""
+    expected = "sha256=" + hmac.new(
+        secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+@app.post("/v1/hooks/github")
+async def github_webhook(request: Request) -> WebhookResponse:
+    """Receive GitHub pull_request webhook events for tracked repos."""
+    body = await request.body()
+
+    # Parse payload
+    try:
+        payload = await request.json()
+    except Exception:
+        raise APIError(400, "invalid_payload", "Invalid JSON payload")
+
+    # Must be a pull_request event
+    event_type = request.headers.get("x-github-event", "")
+    if event_type != "pull_request":
+        return WebhookResponse(
+            action="ignored", skipped=True,
+            reason=f"Event type '{event_type}' is not pull_request")
+
+    action = payload.get("action", "")
+    pr = payload.get("pull_request", {})
+    repo_full = payload.get("repository", {}).get("full_name", "")
+    repo_slug = repo_full.strip().lower()
+
+    # Look up tracked repo
+    tracked = app.state.tracked_repos.get(repo_slug)
+    if tracked is None:
+        raise APIError(404, "repo_not_tracked",
+                       f"Repo '{repo_full}' is not tracked")
+    if not tracked.enabled:
+        return WebhookResponse(
+            action=action, skipped=True,
+            reason=f"Repo '{repo_full}' is disabled")
+
+    # Validate HMAC signature
+    if tracked.webhook_secret:
+        signature = request.headers.get("x-hub-signature-256", "")
+        if not signature:
+            raise APIError(401, "signature_missing",
+                           "X-Hub-Signature-256 header required")
+        if not _verify_webhook_signature(body, signature,
+                                         tracked.webhook_secret):
+            raise APIError(401, "signature_invalid",
+                           "Webhook signature verification failed")
+
+    # Route by action
+    if action == "opened":
+        return await _handle_pr_opened(tracked, pr, repo_slug)
+    elif action == "closed":
+        return await _handle_pr_closed(pr, repo_slug)
+    else:
+        return WebhookResponse(
+            action=action, skipped=True,
+            reason=f"Action '{action}' is not handled")
+
+
+async def _handle_pr_opened(tracked: TrackedRepo, pr: dict,
+                            repo_slug: str) -> WebhookResponse:
+    """Create a market for a newly opened PR."""
+    import math as _math
+
+    pr_num = pr.get("number")
+    pr_title = pr.get("title", "")
+    pr_url = pr.get("html_url", "")
+
+    now = datetime.now(timezone.utc)
+    today = now.strftime("%Y-%m-%d")
+    tomorrow = (now + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0)
+    deadline = tomorrow.isoformat().replace("+00:00", "Z")
+    next_liquidity = (now + timedelta(minutes=LIQUIDITY_RAMP_INTERVAL_MINUTES)
+                      ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    category_id = f"{repo_slug}#{pr_num}@{today}"
+
+    # Idempotency: check if market already exists
+    for m in app.state.me.markets.values():
+        if m.category == "pr_merge" and m.category_id == category_id:
+            return WebhookResponse(
+                action="opened", market_id=m.id, skipped=True,
+                reason=f"Market already exists for {category_id}")
+
+    question = f"Will PR #{pr_num} '{pr_title}' merge by {deadline}?"
+    funding = Decimal(LIQUIDITY_INITIAL)
+    b = funding / Decimal(str(_math.log(2)))
+
+    # Determine funding source
+    funding_account_id = int(TREASURY_ACCOUNT_ID) if TREASURY_ACCOUNT_ID else None
+
+    metadata = {
+        "pr_number": pr_num,
+        "pr_url": pr_url,
+        "repo": repo_slug,
+        "liquidity_budget": LIQUIDITY_BUDGET,
+        "liquidity_step": LIQUIDITY_STEP,
+        "liquidity_steps_remaining": LIQUIDITY_RAMP_STEPS,
+        "next_liquidity_at": next_liquidity,
+    }
+
+    async with app.state.lock:
+        try:
+            market, amm = app.state.me.create_market(
+                question=question,
+                category="pr_merge",
+                category_id=category_id,
+                metadata=metadata,
+                b=b,
+                deadline=deadline,
+                funding_account_id=funding_account_id,
+            )
+        except (ValueError, InsufficientBalance) as e:
+            raise translate_engine_error(e)
+        _save()
+
+    logger.info("Webhook created market %d for %s", market.id, category_id)
+    return WebhookResponse(action="opened", market_id=market.id)
+
+
+async def _handle_pr_closed(pr: dict, repo_slug: str) -> WebhookResponse:
+    """Resolve all open markets for a closed PR."""
+    pr_num = pr.get("number")
+    merged = pr.get("merged", False)
+    outcome = "yes" if merged else "no"
+    category_prefix = f"{repo_slug}#{pr_num}"
+
+    resolved_ids = []
+    async with app.state.lock:
+        for m in list(app.state.me.markets.values()):
+            if (m.category == "pr_merge"
+                    and m.category_id.startswith(category_prefix)
+                    and m.status == "open"):
+                try:
+                    app.state.me.resolve(m.id, outcome)
+                    resolved_ids.append(m.id)
+                except ValueError:
+                    pass  # already resolved/void
+        if resolved_ids:
+            _save()
+
+    if not resolved_ids:
+        return WebhookResponse(
+            action="closed", skipped=True, resolution=outcome,
+            reason=f"No open markets found for {category_prefix}")
+
+    logger.info("Webhook resolved %d markets for %s as %s",
+                len(resolved_ids), category_prefix, outcome)
+    return WebhookResponse(
+        action="closed", market_id=resolved_ids[0], resolution=outcome)

--- a/core/api_models.py
+++ b/core/api_models.py
@@ -172,3 +172,24 @@ class HealthResponse(BaseModel):
     status: str
     markets: int
     accounts: int
+
+
+# --- Tracked Repos ---
+
+class AddRepoRequest(BaseModel):
+    repo: str                          # "snapshot-labs/sx-monorepo"
+    webhook_secret: str | None = None  # HMAC secret for signature validation
+    enabled: bool = True
+
+class TrackedRepoResponse(BaseModel):
+    repo: str
+    enabled: bool
+    has_webhook_secret: bool
+    added_at: str
+
+class WebhookResponse(BaseModel):
+    action: str
+    market_id: int | None = None
+    resolution: str | None = None
+    skipped: bool = False
+    reason: str | None = None

--- a/core/cli.py
+++ b/core/cli.py
@@ -51,7 +51,7 @@ def file_lock(path):
 
 def load_or_create(path):
     if os.path.exists(path):
-        risk, me, _auth = load_snapshot(path)
+        risk, me, _auth, _repos = load_snapshot(path)
         return risk, me
     reset_counters()
     risk = RiskEngine()

--- a/core/models.py
+++ b/core/models.py
@@ -337,3 +337,25 @@ class Market:
     def position(self, account_id: int) -> dict[str, Decimal]:
         return self.positions.get(account_id,
                                   {o: ZERO for o in self.outcomes})
+
+
+# ---------------------------------------------------------------------------
+# Tracked repos (for external webhook-based market creation)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrackedRepo:
+    """A GitHub repo tracked for PR prediction markets via webhook."""
+    repo: str                           # "snapshot-labs/sx-monorepo"
+    webhook_secret: Optional[str]       # HMAC secret for signature validation
+    enabled: bool = True                # kill switch
+    added_at: str = field(default_factory=_now)
+
+    @staticmethod
+    def new(repo: str, webhook_secret: Optional[str] = None,
+            enabled: bool = True) -> "TrackedRepo":
+        return TrackedRepo(
+            repo=repo,
+            webhook_secret=webhook_secret,
+            enabled=enabled,
+        )

--- a/core/persistence.py
+++ b/core/persistence.py
@@ -19,7 +19,7 @@ import os
 from decimal import Decimal
 
 from core.models import (
-    Lock, Account, Transaction, TradeLeg, Trade, Market,
+    Lock, Account, Transaction, TradeLeg, Trade, Market, TrackedRepo,
     ZERO, _counters, set_counter, reset_counters,
 )
 from core.risk_engine import RiskEngine
@@ -153,7 +153,7 @@ def _load_market(d: dict) -> Market:
 # Schema versioning
 # ---------------------------------------------------------------------------
 
-CURRENT_VERSION = 2
+CURRENT_VERSION = 3
 
 
 def _migrate_1_to_2(state: dict) -> dict:
@@ -163,7 +163,14 @@ def _migrate_1_to_2(state: dict) -> dict:
     return state
 
 
-_MIGRATIONS: dict[int, callable] = {1: _migrate_1_to_2}
+def _migrate_2_to_3(state: dict) -> dict:
+    """Add tracked_repos section to snapshot."""
+    state["tracked_repos"] = {}
+    state["version"] = 3
+    return state
+
+
+_MIGRATIONS: dict[int, callable] = {1: _migrate_1_to_2, 2: _migrate_2_to_3}
 
 
 def _apply_migrations(state: dict) -> dict:
@@ -184,9 +191,10 @@ def _apply_migrations(state: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 def save_snapshot(risk: RiskEngine, market_engine: MarketEngine,
-                  path: str, auth_store=None) -> None:
+                  path: str, auth_store=None,
+                  tracked_repos: dict | None = None) -> None:
     """
-    Save complete RE + ME + auth state to a JSON file.
+    Save complete RE + ME + auth + tracked_repos state to a JSON file.
     Atomic: writes to .tmp then renames.
     """
     state = {
@@ -196,6 +204,10 @@ def save_snapshot(risk: RiskEngine, market_engine: MarketEngine,
         "transactions": [_serialize(tx) for tx in risk.transactions],
         "markets": [_serialize(m) for m in market_engine.markets.values()],
         "auth": _serialize_auth(auth_store) if auth_store else {"users": []},
+        "tracked_repos": {
+            slug: _serialize(repo)
+            for slug, repo in (tracked_repos or {}).items()
+        },
     }
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
@@ -258,11 +270,24 @@ def _load_auth(auth_data: dict):
     return store
 
 
+def _load_tracked_repos(data: dict) -> dict[str, TrackedRepo]:
+    """Load tracked repos from snapshot data."""
+    repos = {}
+    for slug, rdata in data.items():
+        repos[slug] = TrackedRepo(
+            repo=rdata["repo"],
+            webhook_secret=rdata.get("webhook_secret"),
+            enabled=rdata.get("enabled", True),
+            added_at=rdata.get("added_at", ""),
+        )
+    return repos
+
+
 def load_snapshot(path: str) -> tuple:
     """
-    Load RE + ME + auth state from a JSON snapshot.
+    Load RE + ME + auth + tracked_repos state from a JSON snapshot.
     Applies migrations automatically if the snapshot is an older version.
-    Returns (risk_engine, market_engine, auth_store) ready to use.
+    Returns (risk_engine, market_engine, auth_store, tracked_repos) ready to use.
     auth_store is None if the auth module is not available.
     """
     with open(path) as f:
@@ -292,4 +317,7 @@ def load_snapshot(path: str) -> tuple:
     # Restore auth
     auth_store = _load_auth(state.get("auth", {"users": []}))
 
-    return risk, me, auth_store
+    # Restore tracked repos
+    tracked_repos = _load_tracked_repos(state.get("tracked_repos", {}))
+
+    return risk, me, auth_store, tracked_repos

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -45,6 +45,7 @@ async def client():
     app.state.risk = RiskEngine()
     app.state.me = MarketEngine(app.state.risk)
     app.state.auth_store = AuthStore()
+    app.state.tracked_repos = {}
     app.state.lock = asyncio.Lock()
 
     # Reset rate limiter
@@ -837,7 +838,7 @@ class TestPersistence:
 
         # Reload state from disk
         from core.persistence import load_snapshot
-        risk, me, auth_store = load_snapshot("/tmp/futarchy_test_state.json")
+        risk, me, auth_store, tracked_repos = load_snapshot("/tmp/futarchy_test_state.json")
 
         # Verify market exists
         assert mid in me.markets
@@ -933,3 +934,289 @@ class TestDashboard:
             f"Dashboard fetches API paths that don't exist as routes: {missing}. "
             f"Registered /v1 routes: {sorted('/v1/' + r for r in registered)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tracked Repos Admin
+# ---------------------------------------------------------------------------
+
+class TestTrackedRepos:
+    async def test_add_list_delete_repo(self, client):
+        # List — empty initially
+        resp = await client.get("/v1/admin/repos", headers=ADMIN_HEADERS)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+        # Add a repo
+        resp = await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                                  json={"repo": "snapshot-labs/sx-monorepo",
+                                        "webhook_secret": "test-secret"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["repo"] == "snapshot-labs/sx-monorepo"
+        assert data["enabled"] is True
+        assert data["has_webhook_secret"] is True
+
+        # List shows it
+        resp = await client.get("/v1/admin/repos", headers=ADMIN_HEADERS)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        # Delete
+        resp = await client.delete(
+            "/v1/admin/repos/snapshot-labs/sx-monorepo",
+            headers=ADMIN_HEADERS)
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == "snapshot-labs/sx-monorepo"
+
+        # List — empty again
+        resp = await client.get("/v1/admin/repos", headers=ADMIN_HEADERS)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_add_repo_invalid_format(self, client):
+        resp = await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                                  json={"repo": "no-slash"})
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "invalid_repo"
+
+    async def test_delete_nonexistent_repo(self, client):
+        resp = await client.delete(
+            "/v1/admin/repos/not/tracked",
+            headers=ADMIN_HEADERS)
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "repo_not_found"
+
+    async def test_add_repo_requires_admin(self, client):
+        resp = await client.post("/v1/admin/repos",
+                                  json={"repo": "owner/name"})
+        assert resp.status_code == 401
+
+    async def test_add_repo_upsert(self, client):
+        """Adding the same repo twice updates it."""
+        await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                          json={"repo": "owner/name",
+                                "webhook_secret": "s1"})
+        resp = await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                                  json={"repo": "owner/name",
+                                        "webhook_secret": "s2"})
+        assert resp.status_code == 200
+
+        repos = (await client.get("/v1/admin/repos",
+                                   headers=ADMIN_HEADERS)).json()
+        assert len(repos) == 1
+
+
+# ---------------------------------------------------------------------------
+# GitHub Webhook
+# ---------------------------------------------------------------------------
+
+def _make_webhook_payload(action, pr_number=42, pr_title="Test PR",
+                          repo="snapshot-labs/sx-monorepo",
+                          merged=False):
+    """Build a GitHub pull_request webhook payload."""
+    return {
+        "action": action,
+        "pull_request": {
+            "number": pr_number,
+            "title": pr_title,
+            "html_url": f"https://github.com/{repo}/pull/{pr_number}",
+            "merged": merged,
+        },
+        "repository": {
+            "full_name": repo,
+        },
+    }
+
+
+def _sign_payload(payload_bytes: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature like GitHub does."""
+    import hashlib, hmac as _hmac, json
+    sig = _hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={sig}"
+
+
+class TestWebhook:
+    REPO = "snapshot-labs/sx-monorepo"
+    SECRET = "webhook-test-secret"
+
+    async def _setup_repo(self, client, secret=None):
+        """Add tracked repo and optionally a treasury."""
+        # Ensure tracked_repos is initialized
+        if not hasattr(app.state, "tracked_repos"):
+            app.state.tracked_repos = {}
+
+        await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                          json={"repo": self.REPO,
+                                "webhook_secret": secret or self.SECRET})
+
+        # Create a treasury with funds
+        resp = await client.post("/v1/admin/accounts", headers=ADMIN_HEADERS)
+        treasury_id = resp.json()["account_id"]
+        await client.post("/v1/admin/mint", headers=ADMIN_HEADERS,
+                          json={"account_id": treasury_id, "amount": "10000"})
+
+        # Set the treasury env var
+        import core.api
+        core.api.TREASURY_ACCOUNT_ID = str(treasury_id)
+        return treasury_id
+
+    async def _post_webhook(self, client, payload, secret=None):
+        """Post a webhook event with proper signature."""
+        import json as _json
+        body = _json.dumps(payload).encode()
+        headers = {"x-github-event": "pull_request"}
+        if secret:
+            headers["x-hub-signature-256"] = _sign_payload(body, secret)
+        return await client.post("/v1/hooks/github", content=body,
+                                  headers={**headers,
+                                           "content-type": "application/json"})
+
+    async def test_pr_opened_creates_market(self, client):
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("opened", pr_number=10,
+                                         pr_title="Add feature")
+        resp = await self._post_webhook(client, payload, self.SECRET)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "opened"
+        assert data["market_id"] is not None
+        assert data["skipped"] is False
+
+        # Verify market was actually created
+        markets = (await client.get("/v1/markets",
+                                     params={"category": "pr_merge"})).json()
+        assert len(markets) == 1
+        assert "#10@" in markets[0]["category_id"]
+        assert markets[0]["question"].startswith("Will PR #10")
+
+    async def test_pr_opened_idempotent(self, client):
+        """Duplicate open events don't create duplicate markets."""
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("opened", pr_number=10)
+
+        resp1 = await self._post_webhook(client, payload, self.SECRET)
+        assert resp1.status_code == 200
+        mid1 = resp1.json()["market_id"]
+
+        resp2 = await self._post_webhook(client, payload, self.SECRET)
+        assert resp2.status_code == 200
+        assert resp2.json()["skipped"] is True
+        assert resp2.json()["market_id"] == mid1
+
+        # Only one market exists
+        markets = (await client.get("/v1/markets",
+                                     params={"category": "pr_merge"})).json()
+        assert len(markets) == 1
+
+    async def test_pr_closed_merged_resolves_yes(self, client):
+        await self._setup_repo(client)
+
+        # First create market
+        open_payload = _make_webhook_payload("opened", pr_number=20)
+        resp = await self._post_webhook(client, open_payload, self.SECRET)
+        mid = resp.json()["market_id"]
+
+        # Then close/merge
+        close_payload = _make_webhook_payload("closed", pr_number=20,
+                                               merged=True)
+        resp = await self._post_webhook(client, close_payload, self.SECRET)
+        assert resp.status_code == 200
+        assert resp.json()["resolution"] == "yes"
+
+        # Verify market is resolved
+        detail = (await client.get(f"/v1/markets/{mid}")).json()
+        assert detail["status"] == "resolved"
+        assert detail["resolution"] == "yes"
+
+    async def test_pr_closed_not_merged_resolves_no(self, client):
+        await self._setup_repo(client)
+
+        open_payload = _make_webhook_payload("opened", pr_number=30)
+        resp = await self._post_webhook(client, open_payload, self.SECRET)
+        mid = resp.json()["market_id"]
+
+        close_payload = _make_webhook_payload("closed", pr_number=30,
+                                               merged=False)
+        resp = await self._post_webhook(client, close_payload, self.SECRET)
+        assert resp.status_code == 200
+        assert resp.json()["resolution"] == "no"
+
+        detail = (await client.get(f"/v1/markets/{mid}")).json()
+        assert detail["status"] == "resolved"
+        assert detail["resolution"] == "no"
+
+    async def test_untracked_repo_rejected(self, client):
+        # Don't add any repo — post directly
+        if not hasattr(app.state, "tracked_repos"):
+            app.state.tracked_repos = {}
+        payload = _make_webhook_payload("opened", repo="unknown/repo")
+        resp = await self._post_webhook(client, payload)
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "repo_not_tracked"
+
+    async def test_disabled_repo_skipped(self, client):
+        if not hasattr(app.state, "tracked_repos"):
+            app.state.tracked_repos = {}
+        await client.post("/v1/admin/repos", headers=ADMIN_HEADERS,
+                          json={"repo": self.REPO,
+                                "webhook_secret": self.SECRET,
+                                "enabled": False})
+        payload = _make_webhook_payload("opened")
+        resp = await self._post_webhook(client, payload, self.SECRET)
+        assert resp.status_code == 200
+        assert resp.json()["skipped"] is True
+
+    async def test_invalid_signature_rejected(self, client):
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("opened")
+        # Sign with wrong secret
+        resp = await self._post_webhook(client, payload, "wrong-secret")
+        assert resp.status_code == 401
+        assert resp.json()["error"]["code"] == "signature_invalid"
+
+    async def test_missing_signature_rejected(self, client):
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("opened")
+        # No signature header
+        import json as _json
+        body = _json.dumps(payload).encode()
+        resp = await client.post("/v1/hooks/github", content=body,
+                                  headers={"x-github-event": "pull_request",
+                                           "content-type": "application/json"})
+        assert resp.status_code == 401
+        assert resp.json()["error"]["code"] == "signature_missing"
+
+    async def test_non_pr_event_ignored(self, client):
+        if not hasattr(app.state, "tracked_repos"):
+            app.state.tracked_repos = {}
+        resp = await client.post("/v1/hooks/github",
+                                  json={"action": "created"},
+                                  headers={"x-github-event": "push"})
+        assert resp.status_code == 200
+        assert resp.json()["skipped"] is True
+
+    async def test_unhandled_action_ignored(self, client):
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("reopened")
+        resp = await self._post_webhook(client, payload, self.SECRET)
+        assert resp.status_code == 200
+        assert resp.json()["skipped"] is True
+
+    async def test_market_metadata_correct(self, client):
+        """Verify the market metadata matches pr-market.yml conventions."""
+        await self._setup_repo(client)
+        payload = _make_webhook_payload("opened", pr_number=55,
+                                         pr_title="Big feature")
+        resp = await self._post_webhook(client, payload, self.SECRET)
+        mid = resp.json()["market_id"]
+
+        detail = (await client.get(f"/v1/markets/{mid}")).json()
+        meta = detail["metadata"]
+        assert meta["pr_number"] == 55
+        assert meta["repo"] == self.REPO
+        assert "pr_url" in meta
+        assert "liquidity_step" in meta
+        assert "liquidity_steps_remaining" in meta
+        assert "next_liquidity_at" in meta
+        assert detail["deadline"] is not None


### PR DESCRIPTION
## Summary

- **Tracked repos admin API** (`GET/POST/DELETE /v1/admin/repos`) — register external GitHub repos for PR market creation without redeployment
- **Webhook endpoint** (`POST /v1/hooks/github`) — receives GitHub `pull_request` events, validates HMAC-SHA256 signatures, creates markets on PR open, resolves on PR close (yes if merged, no if not)
- **Persistence v3 migration** — tracked repos persisted alongside accounts, markets, and auth
- Matches existing `pr-market.yml` conventions: `category=pr_merge`, `category_id="{repo}#{pr}@{date}"`, treasury funding, liquidity ramp metadata

## Files changed

| File | Change |
|------|--------|
| `core/models.py` | `TrackedRepo` dataclass |
| `core/api_models.py` | `AddRepoRequest`, `TrackedRepoResponse`, `WebhookResponse` |
| `core/persistence.py` | v2→v3 migration, serialize/deserialize tracked_repos |
| `core/api.py` | Webhook route, admin repo CRUD, HMAC validation |
| `core/cli.py` | Updated `load_snapshot` unpacking |
| `core/test_api.py` | 16 new tests (webhook lifecycle, idempotency, HMAC, admin CRUD) |

## Test plan

- [x] 101 tests pass (64 API + 37 core), 0 failures
- [x] Webhook creates market with correct category_id, question, deadline, metadata
- [x] Duplicate open events are idempotent (no duplicate markets)
- [x] Close/merged → resolves "yes"; close/not-merged → resolves "no"
- [x] HMAC signature validation (missing, invalid, correct)
- [x] Untracked/disabled repos rejected appropriately
- [x] Non-PR events and unhandled actions ignored gracefully
- [x] Existing persistence test updated for 4-tuple return