### PR TITLE
Auto-void expired markets in the API service

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -62,6 +62,9 @@ LIQUIDITY_STEP = os.environ.get("LIQUIDITY_STEP", "40")
 LIQUIDITY_RAMP_STEPS = int(os.environ.get("LIQUIDITY_RAMP_STEPS", "4"))
 LIQUIDITY_RAMP_INTERVAL_MINUTES = int(os.environ.get("LIQUIDITY_RAMP_INTERVAL_MINUTES", "30"))
 LIQUIDITY_BUDGET = os.environ.get("LIQUIDITY_BUDGET", "200")
+MARKET_EXPIRY_CHECK_INTERVAL_SECONDS = float(
+    os.environ.get("MARKET_EXPIRY_CHECK_INTERVAL_SECONDS", "60")
+)
 
 
 @asynccontextmanager
@@ -81,7 +84,22 @@ async def lifespan(app: FastAPI):
     app.state.auth_store = auth_store or AuthStore()
     app.state.tracked_repos = tracked_repos
     app.state.lock = asyncio.Lock()
-    yield
+    await _reconcile_expired_markets_once()
+
+    app.state.expiry_stop_event = asyncio.Event()
+    app.state.expiry_task = None
+    if MARKET_EXPIRY_CHECK_INTERVAL_SECONDS > 0:
+        app.state.expiry_task = asyncio.create_task(
+            _expired_market_reconciler(app.state.expiry_stop_event)
+        )
+
+    try:
+        yield
+    finally:
+        app.state.expiry_stop_event.set()
+        expiry_task = getattr(app.state, "expiry_task", None)
+        if expiry_task is not None:
+            await expiry_task
 
 
 app = FastAPI(title="Futarchy API", version="0.2.0", lifespan=lifespan)
@@ -93,6 +111,71 @@ def _save():
     save_snapshot(app.state.risk, app.state.me, STATE_PATH,
                   auth_store=app.state.auth_store,
                   tracked_repos=app.state.tracked_repos)
+
+
+def _parse_deadline(deadline: str | None) -> datetime | None:
+    if not deadline:
+        return None
+
+    normalized = deadline
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        logger.warning("Skipping market with invalid deadline: %s", deadline)
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+async def _reconcile_expired_markets_once(
+    now: datetime | None = None,
+) -> list[int]:
+    current = now or datetime.now(timezone.utc)
+    expired_ids: list[int] = []
+
+    async with app.state.lock:
+        for market in list(app.state.me.markets.values()):
+            if market.status != "open":
+                continue
+
+            deadline = _parse_deadline(market.deadline)
+            if deadline is None or deadline > current:
+                continue
+
+            try:
+                app.state.me.void(market.id)
+                expired_ids.append(market.id)
+            except ValueError:
+                continue
+
+        if expired_ids:
+            _save()
+
+    if expired_ids:
+        logger.info("Voided %d expired markets: %s", len(expired_ids), expired_ids)
+
+    return expired_ids
+
+
+async def _expired_market_reconciler(stop_event: asyncio.Event) -> None:
+    while not stop_event.is_set():
+        try:
+            await _reconcile_expired_markets_once()
+        except Exception:
+            logger.exception("Expired market reconciliation failed")
+
+        try:
+            await asyncio.wait_for(
+                stop_event.wait(),
+                timeout=MARKET_EXPIRY_CHECK_INTERVAL_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            continue
 
 
 STATIC_DIR = Path(__file__).resolve().parent.parent / "static"

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -14,6 +14,7 @@ Covers:
 import asyncio
 import os
 import re
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -1220,3 +1221,86 @@ class TestWebhook:
         assert "liquidity_steps_remaining" in meta
         assert "next_liquidity_at" in meta
         assert detail["deadline"] is not None
+
+
+class TestExpiredMarketReconciliation:
+    async def test_startup_voids_expired_markets_loaded_from_snapshot(
+        self, tmp_path
+    ):
+        import core.api as api_module
+        from core.persistence import load_snapshot, save_snapshot
+
+        reset_counters()
+        risk = RiskEngine()
+        me = MarketEngine(risk)
+        auth_store = AuthStore()
+
+        market, _ = me.create_market(
+            question="Will it ship?",
+            category="pr_merge",
+            category_id="repo#1@2026-03-01",
+            metadata={},
+            deadline="2026-03-01T00:00:00Z",
+        )
+
+        state_path = tmp_path / "futarchy_state.json"
+        save_snapshot(
+            risk,
+            me,
+            str(state_path),
+            auth_store=auth_store,
+            tracked_repos={},
+        )
+
+        original_state_path = api_module.STATE_PATH
+        api_module.STATE_PATH = str(state_path)
+        try:
+            async with api_module.lifespan(app):
+                assert app.state.me.markets[market.id].status == "void"
+
+            _, loaded_me, _, _ = load_snapshot(str(state_path))
+            assert loaded_me.markets[market.id].status == "void"
+            assert loaded_me.markets[market.id].resolved_at is not None
+        finally:
+            api_module.STATE_PATH = original_state_path
+
+    async def test_background_reconciler_voids_markets_after_deadline(
+        self, client, monkeypatch
+    ):
+        import core.api as api_module
+
+        monkeypatch.setattr(
+            api_module,
+            "MARKET_EXPIRY_CHECK_INTERVAL_SECONDS",
+            0.01,
+        )
+
+        deadline = (
+            datetime.now(timezone.utc) + timedelta(milliseconds=20)
+        ).isoformat().replace("+00:00", "Z")
+
+        resp = await client.post(
+            "/v1/admin/markets",
+            headers=ADMIN_HEADERS,
+            json={
+                "question": "Will it expire?",
+                "category": "pr_merge",
+                "category_id": "repo#2@2026-03-01",
+                "deadline": deadline,
+            },
+        )
+        mid = resp.json()["market_id"]
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            api_module._expired_market_reconciler(stop_event)
+        )
+        try:
+            await asyncio.sleep(0.1)
+        finally:
+            stop_event.set()
+            await task
+
+        detail = (await client.get(f"/v1/markets/{mid}")).json()
+        assert detail["status"] == "void"
+        assert detail["resolved_at"] is not None


### PR DESCRIPTION
## Summary
- auto-void expired open markets during API startup so stale state is corrected immediately after deploy/restart
- run a background expiry reconciler in the API so deadline handling no longer depends on a repo-specific scheduled workflow
- add regressions for startup reconciliation and in-process deadline expiry

## Root cause
The live API had open markets with deadlines already in the past because deadline expiry was not enforced in the server itself. Market creation and close resolution worked via webhook flows, but expiry relied on external automation. That left tracked repos like  without any expiry path, and also meant stale markets remained open whenever the scheduled rollover workflow did not run.

## Validation
- 
- .....................................................................    [100%]
69 passed in 0.94s
