### PR TITLE
Clarify /v1/health counts and expose user total

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -201,10 +201,15 @@ async def install_script():
 
 @app.get("/v1/health")
 async def health() -> HealthResponse:
+    auth_store = app.state.auth_store
     return HealthResponse(
         status="ok",
         markets=len(app.state.me.markets),
-        accounts=len(app.state.risk.accounts),
+        ledger_accounts=len(app.state.risk.accounts),
+        users=(
+            len(auth_store.users) +
+            len(getattr(auth_store, "local_users", {}))
+        ),
     )
 
 

--- a/core/api_models.py
+++ b/core/api_models.py
@@ -171,7 +171,8 @@ class UpdateMetadataRequest(BaseModel):
 class HealthResponse(BaseModel):
     status: str
     markets: int
-    accounts: int
+    ledger_accounts: int
+    users: int
 
 
 # --- Tracked Repos ---

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -89,7 +89,28 @@ class TestHealth:
         data = resp.json()
         assert data["status"] == "ok"
         assert data["markets"] == 0
-        assert data["accounts"] == 0
+        assert data["ledger_accounts"] == 0
+        assert data["users"] == 0
+
+    async def test_health_separates_ledger_accounts_from_users(self, client):
+        resp = await client.post("/v1/admin/markets", headers=ADMIN_HEADERS,
+                                 json={"question": "Will it rain?",
+                                       "category": "weather",
+                                       "category_id": "weather#1"})
+        assert resp.status_code == 200
+
+        await _mock_auth(client, github_id=1, login="alice")
+
+        resp = await client.post("/v1/auth/register",
+                                 json={"username": "local-user"})
+        assert resp.status_code == 200
+
+        resp = await client.get("/v1/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["markets"] == 1
+        assert data["ledger_accounts"] == 3
+        assert data["users"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- rename the health payload field from `accounts` to `ledger_accounts`
- add a `users` count from the auth store
- cover the new contract with API tests

## Validation
- python3 -m py_compile core/api.py core/api_models.py core/test_api.py
- pytest -q core/test_api.py