### PR TITLE
Switch dashboard auth to GitHub device flow

### DIFF
--- a/cli/futarchy_cli/api.py
+++ b/cli/futarchy_cli/api.py
@@ -60,9 +60,6 @@ class Client:
 
     # ── Auth / user endpoints ──
 
-    def register(self, username: str) -> dict:
-        return self.post("/v1/auth/register", body={"username": username})
-
     def device_auth_start(self) -> dict:
         return self.post("/v1/auth/device", body={})
 

--- a/cli/futarchy_cli/auth.py
+++ b/cli/futarchy_cli/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import sys
 from pathlib import Path
 
@@ -39,7 +40,7 @@ def require_auth() -> str:
 
 
 def login(client) -> None:
-    """Simple registration — pick a username, get an API key."""
+    """GitHub device-flow login."""
     # Check if already logged in
     existing = get_api_key()
     if existing:
@@ -48,32 +49,49 @@ def login(client) -> None:
         print("  Run `futarchy logout` to reset.\n")
         return
 
-    # Prompt for username
     try:
-        username = input("\n  Choose a username: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        print("")
-        sys.exit(1)
-
-    if not username:
-        print("Error: username cannot be empty.", file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        resp = client.register(username)
+        flow = client.device_auth_start()
     except Exception as e:
         print(f"\n  Error: {e}", file=sys.stderr)
         sys.exit(1)
 
+    verification_uri = flow.get("verification_uri", "https://github.com/login/device")
+    user_code = flow.get("user_code", "")
+    device_code = flow.get("device_code", "")
+    interval = int(flow.get("interval", 5))
+
+    print("\n  Sign in with GitHub")
+    print(f"  Open: {verification_uri}")
+    print(f"  Code: {user_code}")
+    print("\n  Waiting for authorization...\n")
+
+    while True:
+        try:
+            resp = client.device_auth_poll(device_code)
+            break
+        except Exception as e:
+            status = getattr(e, "status", None)
+            detail = getattr(e, "detail", str(e))
+            if status == 202:
+                time.sleep(interval)
+                continue
+            if status == 410:
+                print("\n  Device code expired. Run `futarchy login` again.\n",
+                      file=sys.stderr)
+                sys.exit(1)
+            print(f"\n  Error: {detail}", file=sys.stderr)
+            sys.exit(1)
+
     api_key = resp.get("api_key", "")
     account_id = resp.get("account_id", "?")
+    github_login = resp.get("github_login", "")
 
     cfg = load_config()
     cfg["api_key"] = api_key
-    cfg["username"] = username
+    cfg["github_login"] = github_login
     save_config(cfg)
 
-    print(f"\n  Logged in as {username} (account #{account_id})")
+    print(f"\n  Logged in as {github_login} (account #{account_id})")
     print(f"  Key saved to {CONFIG_FILE}")
     print("\n  You have 100 credits to start trading.")
     print("  Try: futarchy markets\n")
@@ -83,6 +101,7 @@ def logout() -> None:
     """Remove saved credentials."""
     cfg = load_config()
     cfg.pop("api_key", None)
+    cfg.pop("github_login", None)
     cfg.pop("username", None)
     save_config(cfg)
     print(f"\n  Logged out. Config cleared at {CONFIG_FILE}\n")

--- a/core/api.py
+++ b/core/api.py
@@ -23,7 +23,6 @@ from fastapi.responses import FileResponse
 from core.api_errors import APIError, api_error_handler, translate_engine_error
 from core.api_models import (
     GitHubAuthRequest, AuthResponse,
-    RegisterRequest, RegisterResponse,
     DeviceFlowStartRequest, DeviceFlowResponse, DeviceFlowPollRequest,
     AccountResponse, LockResponse,
     MarketSummary, MarketDetail, PositionEntry, TradeResponse,
@@ -247,35 +246,6 @@ async def auth_github(req: GitHubAuthRequest) -> AuthResponse:
         api_key=raw_key,
         account_id=user.account_id,
         github_login=user.github_login,
-    )
-
-
-@app.post("/v1/auth/register")
-async def auth_register(req: RegisterRequest) -> RegisterResponse:
-    """Register with just a username. No GitHub required."""
-    username = req.username.strip()
-    if not username or len(username) > 40:
-        raise APIError(400, "invalid_username",
-                       "Username must be 1-40 characters")
-
-    async with app.state.lock:
-        auth_store = app.state.auth_store
-        try:
-            acc = app.state.risk.create_account()
-            if INITIAL_CREDITS > ZERO:
-                app.state.risk.mint(acc.id, INITIAL_CREDITS)
-            user, raw_key = auth_store.register_user(username, acc.id)
-        except ValueError as e:
-            if str(e) == "username_taken":
-                raise APIError(409, "username_taken",
-                               f"Username '{username}' is already taken")
-            raise
-        _save()
-
-    return RegisterResponse(
-        api_key=raw_key,
-        account_id=user.account_id,
-        username=username,
     )
 
 

--- a/core/api_models.py
+++ b/core/api_models.py
@@ -22,14 +22,6 @@ class AuthResponse(BaseModel):
     account_id: int
     github_login: str
 
-class RegisterRequest(BaseModel):
-    username: str
-
-class RegisterResponse(BaseModel):
-    api_key: str
-    account_id: int
-    username: str
-
 class DeviceFlowResponse(BaseModel):
     device_code: str
     user_code: str

--- a/core/auth.py
+++ b/core/auth.py
@@ -41,23 +41,8 @@ class AuthStore:
     def __init__(self):
         self.users: dict[int, User] = {}         # github_id -> User
         self.key_to_user: dict[str, User] = {}   # api_key_hash -> User
-        self.local_users: dict[str, User] = {}   # username -> User (non-GitHub)
-
-    def register_user(self, username: str, account_id: int) -> tuple[User, str]:
-        """Register a local user (no GitHub). Returns (user, raw_api_key)."""
-        if username in self.local_users:
-            raise ValueError("username_taken")
-        raw_key = secrets.token_urlsafe(32)
-        key_hash = _hash_key(raw_key)
-        user = User(
-            github_id=0,
-            github_login=username,
-            account_id=account_id,
-            api_key_hash=key_hash,
-        )
-        self.local_users[username] = user
-        self.key_to_user[key_hash] = user
-        return user, raw_key
+        # Legacy local users may still be loaded from snapshots for auth continuity.
+        self.local_users: dict[str, User] = {}
 
     def create_user(self, github_id: int, github_login: str,
                     account_id: int) -> tuple[User, str]:

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -148,6 +148,57 @@ class TestAuth:
         assert resp.status_code == 401
         assert resp.json()["error"]["code"] == "github_token_invalid"
 
+    async def test_device_flow_start_requires_client_id(self, client):
+        with patch("core.api.GITHUB_CLIENT_ID", ""):
+            resp = await client.post("/v1/auth/device", json={})
+        assert resp.status_code == 501
+        assert resp.json()["error"]["code"] == "device_flow_unavailable"
+
+    async def test_device_flow_start_returns_user_code(self, client):
+        mock = AsyncMock(return_value={
+            "device_code": "device-123",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://github.com/login/device",
+            "expires_in": 900,
+            "interval": 5,
+        })
+        with patch("core.api.GITHUB_CLIENT_ID", "client-id"), \
+                patch("core.api.start_device_flow", mock):
+            resp = await client.post("/v1/auth/device", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_code"] == "ABCD-EFGH"
+        assert data["verification_uri"] == "https://github.com/login/device"
+
+    async def test_device_flow_poll_pending(self, client):
+        mock = AsyncMock(side_effect=ValueError("device_flow_pending"))
+        with patch("core.api.GITHUB_CLIENT_ID", "client-id"), \
+                patch("core.api.poll_device_flow", mock):
+            resp = await client.post("/v1/auth/device/token",
+                                     json={"device_code": "device-123"})
+        assert resp.status_code == 202
+        assert resp.json()["error"]["code"] == "device_flow_pending"
+
+    async def test_device_flow_poll_creates_account(self, client):
+        poll_mock = AsyncMock(return_value={"access_token": "gho_token"})
+        validate_mock = AsyncMock(return_value={"id": 77, "login": "octocat"})
+        with patch("core.api.GITHUB_CLIENT_ID", "client-id"), \
+                patch("core.api.poll_device_flow", poll_mock), \
+                patch("core.api.validate_github_token", validate_mock):
+            resp = await client.post("/v1/auth/device/token",
+                                     json={"device_code": "device-123"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["github_login"] == "octocat"
+
+        me = await client.get("/v1/me", headers=_user_headers(data["api_key"]))
+        assert me.status_code == 200
+        assert me.json()["available"] == "1000"
+
+    async def test_register_endpoint_removed(self, client):
+        resp = await client.post("/v1/auth/register", json={"username": "alice"})
+        assert resp.status_code == 404
+
 
 # ---------------------------------------------------------------------------
 # Auth Boundaries
@@ -882,6 +933,7 @@ class TestDashboard:
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
         assert "Futarchy" in resp.text
+        assert "Sign in with GitHub" in resp.text
 
     async def test_landing_page_links_to_dashboard(self, client):
         """Landing page must contain a link to the dashboard."""
@@ -902,9 +954,9 @@ class TestDashboard:
         # The dashboard uses: api('/markets' + params), api('/markets/' + id), etc.
         # The api() function prepends '/v1', so effective paths are /v1/markets, etc.
         # We extract the path fragments passed to api() and prepend /v1.
-        api_calls = re.findall(r"api\(['\"]([^'\"]+)['\"]", dashboard_html)
+        api_calls = re.findall(r"(?:api|requestJson)\(['\"]([^'\"]+)['\"]", dashboard_html)
         # Also catch template-literal patterns like api('/markets/' + id)
-        api_calls += re.findall(r"api\(['\"/]([^'\"+ )]+)", dashboard_html)
+        api_calls += re.findall(r"(?:api|requestJson)\(['\"/]([^'\"+ )]+)", dashboard_html)
 
         # Normalize: strip leading slash, dedupe
         raw_paths = set()

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -19,6 +19,7 @@ header .spacer { flex: 1; }
 
 /* Auth bar in header */
 .auth-bar { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.auth-bar .auth-label { color: #8b949e; }
 .auth-bar .username { color: #3fb950; font-weight: 500; }
 .auth-bar .balance { color: #58a6ff; font-family: 'SF Mono', monospace; }
 .auth-bar button { padding: 4px 12px; border-radius: 6px; border: 1px solid #30363d; background: #21262d; color: #e6edf3; cursor: pointer; font-size: 13px; }
@@ -27,10 +28,13 @@ header .spacer { flex: 1; }
 .auth-bar button.logout:hover { background: #3d1f1f33; }
 
 /* Filter tabs */
-.tabs { display: flex; gap: 4px; margin-bottom: 20px; }
+.market-controls { display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin-bottom: 20px; }
+.tabs { display: flex; gap: 4px; }
 .tab { padding: 6px 16px; border-radius: 6px; border: 1px solid #30363d; background: transparent; color: #8b949e; cursor: pointer; font-size: 14px; }
 .tab:hover { color: #e6edf3; border-color: #8b949e; }
 .tab.active { background: #21262d; color: #e6edf3; border-color: #58a6ff; }
+.repo-filter { display: flex; align-items: center; gap: 8px; color: #8b949e; font-size: 13px; }
+.repo-filter select { padding: 6px 10px; border-radius: 6px; border: 1px solid #30363d; background: #161b22; color: #e6edf3; font-size: 13px; }
 
 /* Market cards */
 .market-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin-bottom: 12px; cursor: pointer; transition: border-color 0.15s; }
@@ -43,6 +47,7 @@ header .spacer { flex: 1; }
 .badge-resolved { background: #1a3a5c; color: #58a6ff; }
 .badge-void { background: #3d2e1f; color: #f0883e; }
 .badge-conditional { background: #1a1a2e; color: #b388ff; border: 1px solid #4a3a6e; }
+.repo-pill { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; font-weight: 500; background: #0d1117; color: #8b949e; border: 1px solid #30363d; }
 
 /* Price bar */
 .price-bar-container { margin-bottom: 8px; }
@@ -112,20 +117,29 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
 .loading { text-align: center; padding: 40px; color: #8b949e; }
 .error-msg { text-align: center; padding: 40px; color: #f85149; }
 
-/* --- Auth panel (register/login) --- */
+/* --- Auth panel (GitHub device flow) --- */
 .auth-panel { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; max-width: 400px; margin: 40px auto; }
 .auth-panel h2 { font-size: 18px; margin-bottom: 16px; }
 .auth-panel p { font-size: 13px; color: #8b949e; margin-bottom: 16px; }
-.auth-panel .form-row { display: flex; gap: 8px; margin-bottom: 12px; }
-.auth-panel input[type="text"] { flex: 1; padding: 8px 12px; border-radius: 6px; border: 1px solid #30363d; background: #0d1117; color: #e6edf3; font-size: 14px; outline: none; }
-.auth-panel input[type="text"]:focus { border-color: #58a6ff; }
 .auth-panel .btn-primary { padding: 8px 20px; border-radius: 6px; border: 1px solid #238636; background: #238636; color: #fff; cursor: pointer; font-size: 14px; font-weight: 500; }
 .auth-panel .btn-primary:hover { background: #2ea043; }
 .auth-panel .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.auth-panel .api-key-display { background: #0d1117; border: 1px solid #30363d; border-radius: 6px; padding: 12px; margin-top: 12px; font-family: 'SF Mono', monospace; font-size: 12px; word-break: break-all; color: #f0883e; }
-.auth-panel .api-key-display .label { color: #8b949e; font-family: system-ui; font-size: 12px; display: block; margin-bottom: 4px; }
+.auth-panel .btn-secondary { padding: 8px 14px; border-radius: 6px; border: 1px solid #30363d; background: transparent; color: #e6edf3; cursor: pointer; font-size: 13px; }
+.auth-panel .btn-secondary:hover { border-color: #58a6ff; color: #58a6ff; }
+.auth-panel .device-card { background: #0d1117; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin: 16px 0; }
+.auth-panel .device-label { font-size: 12px; color: #8b949e; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+.auth-panel .device-code { display: block; font-family: 'SF Mono', 'Cascadia Code', 'Consolas', monospace; font-size: 30px; letter-spacing: 0.16em; color: #e6edf3; margin-bottom: 12px; word-break: break-word; }
+.auth-panel .device-actions { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.auth-panel .status { display: flex; align-items: center; gap: 10px; min-height: 20px; font-size: 13px; color: #8b949e; margin-top: 12px; }
+.auth-panel .status.waiting { color: #58a6ff; }
+.auth-panel .status.error { color: #f85149; }
+.auth-panel .spinner { width: 14px; height: 14px; border-radius: 50%; border: 2px solid #30363d; border-top-color: #58a6ff; animation: spin 0.8s linear infinite; }
 .auth-panel .success-msg { color: #3fb950; font-size: 13px; margin-top: 8px; }
 .auth-panel .error { color: #f85149; font-size: 13px; margin-top: 8px; }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
 
 /* --- Trading panel --- */
 .trade-panel { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; margin-bottom: 24px; }
@@ -202,34 +216,48 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
   const app = document.getElementById('app');
   const authBar = document.getElementById('auth-bar');
   let pollTimer = null;
+  let authPollTimer = null;
+  let authFlowState = null;
   let currentFilter = 'open';
+  let currentRepoFilter = sessionStorage.getItem('futarchy_repo_filter') || 'all';
 
   // --- Auth state ---
   function getAuth() {
     const key = localStorage.getItem('futarchy_api_key');
-    const username = localStorage.getItem('futarchy_username');
+    const githubLogin = localStorage.getItem('futarchy_github_login');
     const accountId = localStorage.getItem('futarchy_account_id');
-    if (key && username) return { key, username, accountId };
+    if (key && githubLogin) return { key, githubLogin, accountId };
     return null;
   }
 
-  function setAuth(apiKey, username, accountId) {
+  function setAuth(apiKey, githubLogin, accountId) {
     localStorage.setItem('futarchy_api_key', apiKey);
-    localStorage.setItem('futarchy_username', username);
+    localStorage.setItem('futarchy_github_login', githubLogin);
+    localStorage.removeItem('futarchy_username');
     localStorage.setItem('futarchy_account_id', String(accountId));
   }
 
   function clearAuth() {
+    clearAuthPolling();
+    authFlowState = null;
     localStorage.removeItem('futarchy_api_key');
+    localStorage.removeItem('futarchy_github_login');
     localStorage.removeItem('futarchy_username');
     localStorage.removeItem('futarchy_account_id');
+  }
+
+  function clearAuthPolling() {
+    if (authPollTimer) {
+      clearTimeout(authPollTimer);
+      authPollTimer = null;
+    }
   }
 
   // --- Render auth bar ---
   async function renderAuthBar() {
     const auth = getAuth();
     if (!auth) {
-      authBar.innerHTML = '<button id="login-btn">Sign Up / Log In</button>';
+      authBar.innerHTML = '<button id="login-btn">Sign in with GitHub</button>';
       document.getElementById('login-btn').onclick = () => {
         location.hash = '#/auth';
       };
@@ -241,7 +269,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       const me = await apiAuth('/me');
       balanceText = fmtVal(me.available) + ' credits';
     } catch (e) {
-      if (e.message && e.message.includes('401')) {
+      if (e.status === 401) {
         clearAuth();
         renderAuthBar();
         return;
@@ -249,7 +277,8 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       balanceText = '...';
     }
     authBar.innerHTML = `
-      <span class="username">${esc(auth.username)}</span>
+      <span class="auth-label">Signed in as</span>
+      <span class="username">${esc(auth.githubLogin)}</span>
       <span class="balance">${balanceText}</span>
       <button id="portfolio-btn">Portfolio</button>
       <button id="logout-btn" class="logout">Logout</button>
@@ -263,23 +292,50 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
   }
 
   // --- API helpers ---
+  async function requestJson(path, opts) {
+    const resp = await fetch('/v1' + path, opts);
+    let data = null;
+    try {
+      data = await resp.json();
+    } catch (_) {}
+    return { resp, data };
+  }
+
+  function getErrorMessage(data, fallback) {
+    if (data && data.error && data.error.message) return data.error.message;
+    if (data && data.detail) return data.detail;
+    if (data && data.message) return data.message;
+    return fallback;
+  }
+
   async function api(path) {
-    const resp = await fetch('/v1' + path);
-    if (!resp.ok) throw new Error('API ' + resp.status);
-    return resp.json();
+    const result = await requestJson(path);
+    if (!result.resp.ok) {
+      const error = new Error(getErrorMessage(result.data, 'API ' + result.resp.status));
+      error.status = result.resp.status;
+      throw error;
+    }
+    return result.data;
   }
 
   async function apiAuth(path, opts) {
     const auth = getAuth();
-    if (!auth) throw new Error('Not authenticated');
-    const headers = { 'Authorization': 'Bearer ' + auth.key, 'Content-Type': 'application/json' };
-    const resp = await fetch('/v1' + path, Object.assign({ headers }, opts || {}));
-    if (!resp.ok) {
-      let errMsg = 'API ' + resp.status;
-      try { const data = await resp.json(); errMsg = data.detail || data.message || errMsg; } catch (_) {}
-      throw new Error(errMsg);
+    if (!auth) {
+      const error = new Error('Not authenticated');
+      error.status = 401;
+      throw error;
     }
-    return resp.json();
+    const headers = Object.assign(
+      { 'Authorization': 'Bearer ' + auth.key, 'Content-Type': 'application/json' },
+      (opts && opts.headers) || {},
+    );
+    const result = await requestJson(path, Object.assign({}, opts || {}, { headers }));
+    if (!result.resp.ok) {
+      const error = new Error(getErrorMessage(result.data, 'API ' + result.resp.status));
+      error.status = result.resp.status;
+      throw error;
+    }
+    return result.data;
   }
 
   function pct(v) { return (parseFloat(v) * 100).toFixed(1); }
@@ -301,6 +357,16 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
   }
   function badgeClass(status) {
     return 'badge badge-' + status;
+  }
+  function marketRepo(m) {
+    if (m.metadata && m.metadata.repo) return m.metadata.repo;
+    if (!m.category_id) return '';
+    return m.category_id.split('#')[0] || '';
+  }
+  function shortRepo(repo) {
+    if (!repo) return 'unknown';
+    const parts = repo.split('/');
+    return parts[parts.length - 1] || repo;
   }
 
   // --- LMSR helpers (lightweight, for labels + estimates) ---
@@ -395,6 +461,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
 
   function route() {
     clearInterval(pollTimer);
+    clearAuthPolling();
     const hash = location.hash || '#/';
     const marketMatch = hash.match(/^#\/market\/(\d+)$/);
     if (hash === '#/auth') {
@@ -416,62 +483,147 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       location.hash = '#/portfolio';
       return;
     }
+    const flow = authFlowState;
+    const isWaiting = !!(flow && flow.status === 'waiting');
+    const isExpired = !!(flow && flow.status === 'expired');
+    const hasCode = !!(flow && flow.userCode);
+
     app.innerHTML = `
       <a class="back-link" href="#/">\u2190 Markets</a>
       <div class="auth-panel">
-        <h2>Create Account</h2>
-        <p>Pick a username to get started. You will receive 100 credits to trade with. No email or password required.</p>
-        <div class="form-row">
-          <input type="text" id="reg-username" placeholder="Username" maxlength="40" autocomplete="off">
-          <button class="btn-primary" id="reg-btn">Register</button>
+        <h2>Sign in with GitHub</h2>
+        <p>Authorize with GitHub device flow. On first login, Futarchy creates your account from your GitHub identity and credits it with 100 play-money credits.</p>
+        ${hasCode ? `
+          <div class="device-card">
+            <div class="device-label">One-time code</div>
+            <span class="device-code">${esc(flow.userCode)}</span>
+            <div class="device-actions">
+              <button class="btn-secondary" id="copy-code-btn">Copy code</button>
+              <a href="${esc(flow.verificationUri)}" target="_blank" rel="noopener">Open GitHub verification page</a>
+            </div>
+          </div>
+        ` : ''}
+        <div class="device-actions">
+          <button class="btn-primary" id="device-login-btn">${hasCode ? 'Restart sign-in' : 'Sign in with GitHub'}</button>
+          ${isExpired ? '<button class="btn-secondary" id="retry-login-btn">Try again</button>' : ''}
         </div>
-        <div id="reg-feedback"></div>
+        <div class="status ${isWaiting ? 'waiting' : flow && flow.status === 'error' ? 'error' : ''}" id="device-feedback">
+          ${isWaiting ? '<span class="spinner" aria-hidden="true"></span>' : ''}
+          <span>${esc(flow && flow.message ? flow.message : 'Click the button to start GitHub sign-in.')}</span>
+        </div>
       </div>
     `;
-    const input = document.getElementById('reg-username');
-    const btn = document.getElementById('reg-btn');
-    const feedback = document.getElementById('reg-feedback');
+    const startBtn = document.getElementById('device-login-btn');
+    const retryBtn = document.getElementById('retry-login-btn');
+    const copyBtn = document.getElementById('copy-code-btn');
 
-    async function doRegister() {
-      const username = input.value.trim();
-      if (!username) { feedback.innerHTML = '<div class="error">Enter a username.</div>'; return; }
-      btn.disabled = true;
-      btn.textContent = 'Creating...';
+    function scheduleDevicePoll(delayMs) {
+      clearAuthPolling();
+      authPollTimer = setTimeout(pollDeviceFlow, delayMs);
+    }
+
+    async function startDeviceFlow() {
+      clearAuthPolling();
+      authFlowState = { status: 'waiting', message: 'Requesting GitHub device code...' };
+      renderAuthPanel();
       try {
-        const resp = await fetch('/v1/auth/register', {
+        const result = await requestJson('/auth/device', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username }),
+          body: JSON.stringify({}),
         });
-        const data = await resp.json();
-        if (!resp.ok) {
-          feedback.innerHTML = '<div class="error">' + esc(data.detail || data.message || 'Registration failed') + '</div>';
-          btn.disabled = false;
-          btn.textContent = 'Register';
+        if (!result.resp.ok) {
+          authFlowState = {
+            status: 'error',
+            message: getErrorMessage(result.data, 'Failed to start GitHub sign-in.'),
+          };
+          renderAuthPanel();
           return;
         }
-        setAuth(data.api_key, username, data.account_id);
-        feedback.innerHTML = `
-          <div class="success-msg">Account created! You have 100 credits.</div>
-          <div class="api-key-display">
-            <span class="label">Your API key (save it!):</span>
-            ${esc(data.api_key)}
-          </div>
-        `;
-        btn.style.display = 'none';
-        input.style.display = 'none';
-        renderAuthBar();
-        setTimeout(() => { location.hash = '#/'; }, 2000);
+        authFlowState = {
+          deviceCode: result.data.device_code,
+          userCode: result.data.user_code,
+          verificationUri: result.data.verification_uri,
+          intervalMs: (result.data.interval || 5) * 1000,
+          expiresAt: Date.now() + ((result.data.expires_in || 900) * 1000),
+          status: 'waiting',
+          message: 'Waiting for GitHub authorization...',
+        };
+        renderAuthPanel();
+        scheduleDevicePoll(authFlowState.intervalMs);
       } catch (e) {
-        feedback.innerHTML = '<div class="error">Network error. Try again.</div>';
-        btn.disabled = false;
-        btn.textContent = 'Register';
+        authFlowState = { status: 'error', message: e.message || 'Network error. Try again.' };
+        renderAuthPanel();
       }
     }
 
-    btn.onclick = doRegister;
-    input.onkeydown = (e) => { if (e.key === 'Enter') doRegister(); };
-    input.focus();
+    async function pollDeviceFlow() {
+      if (!authFlowState || !authFlowState.deviceCode) return;
+      if (Date.now() >= authFlowState.expiresAt) {
+        authFlowState = { status: 'expired', message: 'Code expired. Try again.' };
+        renderAuthPanel();
+        return;
+      }
+
+      try {
+        const result = await requestJson('/auth/device/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ device_code: authFlowState.deviceCode }),
+        });
+
+        if (result.resp.status === 202) {
+          authFlowState.message = 'Waiting for GitHub authorization...';
+          renderAuthPanel();
+          scheduleDevicePoll(authFlowState.intervalMs);
+          return;
+        }
+
+        if (result.resp.status === 410) {
+          authFlowState = { status: 'expired', message: 'Code expired. Try again.' };
+          renderAuthPanel();
+          return;
+        }
+
+        if (!result.resp.ok) {
+          authFlowState = {
+            status: 'error',
+            message: getErrorMessage(result.data, 'GitHub sign-in failed.'),
+          };
+          renderAuthPanel();
+          return;
+        }
+
+        setAuth(result.data.api_key, result.data.github_login, result.data.account_id);
+        authFlowState = null;
+        renderAuthBar();
+        location.hash = '#/';
+      } catch (e) {
+        authFlowState = { status: 'error', message: e.message || 'Network error. Try again.' };
+        renderAuthPanel();
+      }
+    }
+
+    if (startBtn) startBtn.onclick = startDeviceFlow;
+    if (retryBtn) retryBtn.onclick = startDeviceFlow;
+    if (copyBtn) {
+      copyBtn.onclick = async () => {
+        if (!flow || !flow.userCode) return;
+        try {
+          await navigator.clipboard.writeText(flow.userCode);
+          authFlowState.message = 'Code copied. Finish authorization on GitHub.';
+        } catch (_) {
+          authFlowState.message = 'Copy failed. Copy the code manually.';
+        }
+        renderAuthPanel();
+        if (authFlowState && authFlowState.status === 'waiting') {
+          scheduleDevicePoll(authFlowState.intervalMs);
+        }
+      };
+    }
+    if (isWaiting && flow && flow.deviceCode && !authPollTimer) {
+      scheduleDevicePoll(flow.intervalMs);
+    }
   }
 
   // --- Portfolio View ---
@@ -586,7 +738,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         ` : ''}
       `;
     } catch (e) {
-      if (e.message && e.message.includes('401')) {
+      if (e.status === 401) {
         clearAuth();
         renderAuthBar();
         location.hash = '#/auth';
@@ -606,10 +758,17 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
   }
 
   function renderTabs() {
-    return `<div class="tabs">
-      <button class="tab${currentFilter === 'open' ? ' active' : ''}" data-filter="open">Open</button>
-      <button class="tab${currentFilter === 'settled' ? ' active' : ''}" data-filter="settled">Settled</button>
-      <button class="tab${currentFilter === 'all' ? ' active' : ''}" data-filter="all">All</button>
+    return `<div class="market-controls">
+      <div class="tabs">
+        <button class="tab${currentFilter === 'open' ? ' active' : ''}" data-filter="open">Open</button>
+        <button class="tab${currentFilter === 'settled' ? ' active' : ''}" data-filter="settled">Settled</button>
+        <button class="tab${currentFilter === 'all' ? ' active' : ''}" data-filter="all">All</button>
+      </div>
+      <label class="repo-filter">Repo
+        <select id="repo-filter">
+          <option value="all">All repos</option>
+        </select>
+      </label>
     </div>`;
   }
 
@@ -622,6 +781,31 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         fetchAndRenderMarkets();
       };
     });
+    const repoSelect = document.getElementById('repo-filter');
+    if (repoSelect) {
+      repoSelect.value = currentRepoFilter;
+      repoSelect.onchange = () => {
+        currentRepoFilter = repoSelect.value;
+        sessionStorage.setItem('futarchy_repo_filter', currentRepoFilter);
+        fetchAndRenderMarkets();
+      };
+    }
+  }
+
+  function updateRepoFilterOptions(markets) {
+    const repoSelect = document.getElementById('repo-filter');
+    if (!repoSelect) return;
+
+    const repos = Array.from(new Set(markets.map(marketRepo).filter(Boolean))).sort();
+    repoSelect.innerHTML = '<option value="all">All repos</option>' +
+      repos.map(repo => `<option value="${esc(repo)}">${esc(repo)}</option>`).join('');
+
+    const values = ['all'].concat(repos);
+    if (!values.includes(currentRepoFilter)) {
+      currentRepoFilter = 'all';
+      sessionStorage.setItem('futarchy_repo_filter', currentRepoFilter);
+    }
+    repoSelect.value = currentRepoFilter;
   }
 
   async function fetchAndRenderMarkets() {
@@ -629,13 +813,17 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       const statusParam = currentFilter === 'settled' ? 'resolved,void' : currentFilter;
       const params = currentFilter !== 'all' ? '?status=' + statusParam : '';
       const markets = await api('/markets' + params);
+      updateRepoFilterOptions(markets);
       const area = document.getElementById('markets-area');
       if (!area) return;
-      if (markets.length === 0) {
+      const filteredMarkets = currentRepoFilter === 'all'
+        ? markets
+        : markets.filter(m => marketRepo(m) === currentRepoFilter);
+      if (filteredMarkets.length === 0) {
         area.innerHTML = '<div class="empty">No markets found.</div>';
         return;
       }
-      area.innerHTML = markets.map(m => {
+      area.innerHTML = filteredMarkets.map(m => {
         const yesP = m.prices.yes ? parseFloat(m.prices.yes) : 0;
         const noP = m.prices.no ? parseFloat(m.prices.no) : 0;
         const isVoid = m.status === 'void';
@@ -643,6 +831,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         const noPct = m.status === 'open' ? Math.max(noP * 100, 5) : (m.resolution === 'no' ? 100 : 0);
         const conditional = isConditional(m);
         const liq = liquidityLabel(m.b);
+        const repo = marketRepo(m);
 
         let priceBar;
         if (isVoid) {
@@ -664,6 +853,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
           <div class="card-header">
             <span class="card-question">${esc(m.question)}</span>
             <div class="card-badges">
+              ${repo ? `<span class="repo-pill" title="${esc(repo)}">${esc(shortRepo(repo))}</span>` : ''}
               ${conditional ? '<span class="badge badge-conditional">Conditional</span>' : ''}
               <span class="${badgeClass(m.status)}">${m.status}</span>
             </div>
@@ -701,6 +891,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       ]);
 
       const prUrl = m.metadata && m.metadata.pr_url;
+      const repo = marketRepo(m);
       const conditional = isConditional(m);
       const auth = getAuth();
 
@@ -756,7 +947,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         if (!auth) {
           tradePanel = `<div class="trade-panel">
             <div class="section-title">Trade</div>
-            <div class="login-prompt"><a href="#/auth">Sign up</a> to start trading on this market.</div>
+            <div class="login-prompt"><a href="#/auth">Sign in with GitHub</a> to start trading on this market.</div>
           </div>`;
         } else {
           // Find user's positions for sell limits
@@ -857,6 +1048,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         <div class="detail-header">
           <div class="detail-question">${esc(m.question)}</div>
           <div class="detail-meta">
+            ${repo ? `<span class="repo-pill" title="${esc(repo)}">${esc(repo)}</span>` : ''}
             ${conditional ? '<span class="badge badge-conditional">Conditional</span>' : ''}
             <span class="${badgeClass(m.status)}">${m.status}</span>
             ${m.status === 'open' && m.deadline ? `<span>Closes ${fmtDate(m.deadline)}</span>` : ''}


### PR DESCRIPTION
## Summary
- replace dashboard username signup with GitHub device flow and store `futarchy_github_login` in local storage
- remove the `/v1/auth/register` API path and switch the CLI login flow to device auth so the installed client does not regress
- add repo badges and a client-side repo filter to the dashboard market list
- add device-flow API coverage and update the dashboard route-integrity test for the new auth calls

## Validation
- `python3 -m py_compile core/api.py core/api_models.py core/auth.py core/test_api.py cli/futarchy_cli/api.py cli/futarchy_cli/auth.py`
- `bash -n deploy/deploy.sh`
- `pytest -q core/test_api.py`
- `node -e "const fs=require("fs"); const html=fs.readFileSync("static/dashboard.html","utf8"); const script=html.match(/<script>\n([\s\S]*)\n<\/script>/)[1]; new Function(script); console.log("dashboard js ok");"`

## External Follow-up
- live `POST https://api.futarchy.ai/v1/auth/device` still returns `device_flow_unavailable`
- the GitHub REST and GraphQL APIs do not expose an OAuth-app creation route here; GitHub now requires creating the OAuth app in the web UI under the org Developer settings, then setting `GITHUB_CLIENT_ID` on the server
- I verified the production unit currently has `FUTARCHY_TREASURY_ID=1` but no `GITHUB_CLIENT_ID` configured