### PR TITLE
fix: force github account picker after logout

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -304,24 +304,29 @@ async def health() -> HealthResponse:
 # ---------------------------------------------------------------------------
 
 @app.get("/v1/auth/github/login")
-async def auth_github_login() -> RedirectResponse:
+async def auth_github_login(prompt: str | None = None) -> RedirectResponse:
     """Start GitHub OAuth web flow."""
     if not GITHUB_CLIENT_ID:
         raise APIError(501, "github_oauth_unavailable",
                        "GITHUB_CLIENT_ID not configured")
+    if prompt is not None and prompt != "select_account":
+        raise APIError(400, "github_oauth_invalid_prompt",
+                       "Unsupported OAuth prompt")
 
     state = secrets.token_urlsafe(32)
     async with app.state.lock:
         _prune_github_oauth_states()
         _github_oauth_states()[state] = datetime.now(timezone.utc)
 
-    params = urlencode({
+    params = {
         "client_id": GITHUB_CLIENT_ID,
         "redirect_uri": GITHUB_OAUTH_REDIRECT_URI,
         "state": state,
-    })
+    }
+    if prompt:
+        params["prompt"] = prompt
     return RedirectResponse(
-        url=f"https://github.com/login/oauth/authorize?{params}",
+        url=f"https://github.com/login/oauth/authorize?{urlencode(params)}",
         status_code=302,
     )
 

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -233,6 +233,23 @@ class TestAuth:
         assert len(query["state"][0]) > 20
         assert query["state"][0] in app.state.github_oauth_states
 
+    async def test_oauth_web_login_accepts_select_account_prompt(self, client):
+        with patch("core.api.GITHUB_CLIENT_ID", "client-id"):
+            resp = await client.get("/v1/auth/github/login",
+                                    params={"prompt": "select_account"},
+                                    follow_redirects=False)
+        assert resp.status_code == 302
+        parsed = urlparse(resp.headers["location"])
+        query = parse_qs(parsed.query)
+        assert query["prompt"] == ["select_account"]
+
+    async def test_oauth_web_login_rejects_unknown_prompt(self, client):
+        with patch("core.api.GITHUB_CLIENT_ID", "client-id"):
+            resp = await client.get("/v1/auth/github/login",
+                                    params={"prompt": "consent"})
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "github_oauth_invalid_prompt"
+
     async def test_oauth_callback_rejects_invalid_state(self, client):
         with patch("core.api.GITHUB_CLIENT_ID", "client-id"), \
                 patch("core.api.GITHUB_CLIENT_SECRET", "client-secret"):

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -203,7 +203,8 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
 (function() {
   const app = document.getElementById('app');
   const authBar = document.getElementById('auth-bar');
-  const githubLoginUrl = '/v1/auth/github/login';
+  const githubLoginBaseUrl = '/v1/auth/github/login';
+  const accountPickerKey = 'futarchy_force_account_picker';
   let pollTimer = null;
   let currentFilter = 'open';
   let currentRepoFilter = sessionStorage.getItem('futarchy_repo_filter') || 'all';
@@ -222,6 +223,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
     localStorage.setItem('futarchy_github_login', githubLogin);
     localStorage.removeItem('futarchy_username');
     localStorage.setItem('futarchy_account_id', String(accountId));
+    sessionStorage.removeItem(accountPickerKey);
   }
 
   function clearAuth() {
@@ -229,6 +231,14 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
     localStorage.removeItem('futarchy_github_login');
     localStorage.removeItem('futarchy_username');
     localStorage.removeItem('futarchy_account_id');
+    sessionStorage.setItem(accountPickerKey, '1');
+  }
+
+  function githubLoginUrl() {
+    if (sessionStorage.getItem(accountPickerKey) === '1') {
+      return githubLoginBaseUrl + '?prompt=select_account';
+    }
+    return githubLoginBaseUrl;
   }
 
   function consumeAuthFragment() {
@@ -252,7 +262,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
     if (!auth) {
       authBar.innerHTML = '<button id="login-btn">Sign in with GitHub</button>';
       document.getElementById('login-btn').onclick = () => {
-        window.location.href = githubLoginUrl;
+        window.location.href = githubLoginUrl();
       };
       return;
     }
@@ -483,8 +493,11 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       <div class="auth-panel">
         <h2>Sign in with GitHub</h2>
         <p>Use standard GitHub OAuth. On first login, Futarchy creates your account from your GitHub identity and credits it with 100 play-money credits.</p>
+        ${sessionStorage.getItem(accountPickerKey) === '1'
+          ? '<p>You are signed out locally. The next sign-in will show GitHub account selection instead of silently reusing the last session.</p>'
+          : ''}
         <div class="auth-actions">
-          <a class="btn-primary" href="${githubLoginUrl}">Sign in with GitHub</a>
+          <a class="btn-primary" href="${githubLoginUrl()}">Sign in with GitHub</a>
           <a class="btn-secondary" href="#/">Back to markets</a>
         </div>
       </div>
@@ -812,7 +825,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
         if (!auth) {
           tradePanel = `<div class="trade-panel">
             <div class="section-title">Trade</div>
-            <div class="login-prompt"><a href="${githubLoginUrl}">Sign in with GitHub</a> to start trading on this market.</div>
+            <div class="login-prompt"><a href="${githubLoginUrl()}">Sign in with GitHub</a> to start trading on this market.</div>
           </div>`;
         } else {
           // Find user's positions for sell limits


### PR DESCRIPTION
## Summary
- force GitHub OAuth account selection after a local logout
- preserve normal one-click login when the user has not explicitly logged out
- add tests for the new  behavior and prompt validation

## Why
PR #25 was merged before this logout fix landed on the feature branch, so  still had the confusing silent re-login behavior.

## Validation
- python3 -m py_compile core/api.py core/test_api.py
- pytest -q core/test_api.py
- node dashboard JS parse check
