### PR TITLE
Add paginated account activity to dashboard and CLI

### DIFF
--- a/cli/futarchy_cli/api.py
+++ b/cli/futarchy_cli/api.py
@@ -69,6 +69,13 @@ class Client:
     def me(self) -> dict:
         return self.get("/v1/me")
 
+    def activity(self, limit: int = 20,
+                 before_tx_id: int | None = None) -> dict:
+        params = {"limit": limit}
+        if before_tx_id is not None:
+            params["before_tx_id"] = before_tx_id
+        return self.get("/v1/me/activity", **params)
+
     # ── Trading endpoints ──
 
     def buy(self, market_id: int, outcome: str, budget: float) -> dict:

--- a/cli/futarchy_cli/fmt.py
+++ b/cli/futarchy_cli/fmt.py
@@ -32,6 +32,10 @@ def _bar(yes: float, width: int = 20) -> str:
     return f"{GREEN}{'█' * filled}{DIM}{'░' * empty}{RESET}"
 
 
+def _signed(value: float) -> str:
+    return f"{value:+,.2f}"
+
+
 def markets_table(markets: list[dict]) -> str:
     if not markets:
         return f"\n  {DIM}No open markets.{RESET}\n"
@@ -168,6 +172,56 @@ def user_info(data: dict) -> str:
         lines.append(f"\n  {DIM}No open positions.{RESET}")
 
     lines.append("")
+    lines.append(f"  {DIM}Run futarchy activity for account history.{RESET}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def activity_page(data: dict) -> str:
+    entries = data.get("entries", [])
+    if not entries:
+        return f"\n  {DIM}No account activity yet.{RESET}\n"
+
+    lines = [
+        "",
+        f"  {BOLD}Activity{RESET}",
+        f"  {DIM}{'─' * 56}{RESET}",
+    ]
+
+    for entry in entries:
+        ts = entry.get("created_at", "-")
+        if isinstance(ts, str) and "T" in ts:
+            ts = ts.split("T")[0] + " " + ts.split("T")[1][:5]
+
+        summary = entry.get("summary", entry.get("reason", "activity"))
+        market = entry.get("market_question")
+        if not market and entry.get("market_id"):
+            market = f"Market #{entry['market_id']}"
+
+        avail_delta = float(entry.get("available_delta", 0))
+        frozen_delta = float(entry.get("frozen_delta", 0))
+        total_after = float(entry.get("total_after", 0))
+        available_after = float(entry.get("available_after", 0))
+        frozen_after = float(entry.get("frozen_after", 0))
+
+        lines.append(f"  {BOLD}{summary}{RESET}  {DIM}{ts}{RESET}")
+        if market:
+            lines.append(f"  {DIM}{market}{RESET}")
+        lines.append(
+            f"  Avail {_signed(avail_delta)}  Frozen {_signed(frozen_delta)}"
+        )
+        lines.append(
+            f"  Total {total_after:,.2f}  {DIM}(avail {available_after:,.2f}, frozen {frozen_after:,.2f}){RESET}"
+        )
+        lines.append("")
+
+    if data.get("has_more"):
+        cursor = data.get("next_before_tx_id")
+        lines.append(
+            f"  {DIM}Older entries available: futarchy activity --before-tx-id {cursor}{RESET}"
+        )
+        lines.append("")
+
     return "\n".join(lines)
 
 

--- a/cli/futarchy_cli/main.py
+++ b/cli/futarchy_cli/main.py
@@ -108,6 +108,13 @@ def cmd_me(args) -> int:
     return 0
 
 
+def cmd_activity(args) -> int:
+    client = _authed_client(args)
+    data = client.activity(limit=args.limit, before_tx_id=args.before_tx_id)
+    _output(args, data, fmt.activity_page)
+    return 0
+
+
 def cmd_buy(args) -> int:
     client = _authed_client(args)
     result = client.buy(args.market_id, args.outcome, args.budget)
@@ -158,6 +165,13 @@ def main(argv: list[str] | None = None) -> int:
     # futarchy me
     _sub(sub, "me", help="Show balance and positions")
 
+    # futarchy activity
+    p_activity = _sub(sub, "activity", help="Show account activity")
+    p_activity.add_argument("--limit", type=int, default=20,
+                            help="Number of entries to fetch (default: 20)")
+    p_activity.add_argument("--before-tx-id", type=int, default=None,
+                            help="Fetch entries older than this transaction ID")
+
     # futarchy buy <id> <outcome> <budget>
     p_buy = _sub(sub, "buy", help="Buy outcome tokens")
     p_buy.add_argument("market_id", type=int, help="Market ID")
@@ -183,6 +197,7 @@ def main(argv: list[str] | None = None) -> int:
         "logout": cmd_logout,
         "update": cmd_update,
         "me": cmd_me,
+        "activity": cmd_activity,
         "buy": cmd_buy,
         "sell": cmd_sell,
     }

--- a/core/api.py
+++ b/core/api.py
@@ -20,14 +20,14 @@ from pathlib import Path
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import FileResponse, RedirectResponse
 
 from core.api_errors import APIError, api_error_handler, translate_engine_error
 from core.api_models import (
     AuthResponse,
     DeviceFlowStartRequest, DeviceFlowResponse, DeviceFlowPollRequest,
-    AccountResponse, AccountActivityEntry, LockResponse,
+    AccountResponse, AccountActivityEntry, AccountActivityPage, LockResponse,
     MarketSummary, MarketDetail, PositionEntry, TradeResponse,
     DepthEntry, DepthResponse,
     BuyRequest, SellRequest, TradeResult,
@@ -196,6 +196,47 @@ def _activity_summary(tx, market, outcome: str | None) -> str:
         return "Market settlement"
 
     return reason.replace("_", " ").replace(":", " ")
+
+
+def _build_account_activity(account_id: int) -> list[AccountActivityEntry]:
+    account_txs = [
+        tx for tx in app.state.risk.transactions
+        if tx.account_id == account_id
+    ]
+    available = ZERO
+    frozen = ZERO
+    entries: list[AccountActivityEntry] = []
+
+    for tx in account_txs:
+        available += tx.available_delta
+        frozen += tx.frozen_delta
+        market = app.state.me.markets.get(tx.market_id) if tx.market_id else None
+        outcome = _tx_outcome(tx, market)
+        total_delta = tx.available_delta + tx.frozen_delta
+        entries.append(
+            AccountActivityEntry(
+                tx_id=tx.id,
+                created_at=tx.created_at,
+                summary=_activity_summary(tx, market, outcome),
+                reason=tx.reason,
+                outcome=outcome,
+                available_delta=str(tx.available_delta),
+                frozen_delta=str(tx.frozen_delta),
+                total_delta=str(total_delta),
+                available_after=str(available),
+                frozen_after=str(frozen),
+                total_after=str(available + frozen),
+                market_id=tx.market_id,
+                market_question=market.question if market else None,
+                market_status=market.status if market else None,
+                market_resolution=market.resolution if market else None,
+                trade_id=tx.trade_id,
+                lock_id=tx.lock_id,
+            )
+        )
+
+    entries.reverse()
+    return entries
 
 
 def _github_oauth_states() -> dict[str, datetime]:
@@ -684,46 +725,24 @@ async def get_me(user: AuthUser) -> AccountResponse:
 
 
 @app.get("/v1/me/activity")
-async def get_my_activity(user: AuthUser) -> list[AccountActivityEntry]:
-    """Get authenticated user's account activity with running balances."""
-    account_txs = [
-        tx for tx in app.state.risk.transactions
-        if tx.account_id == user.account_id
-    ]
-    available = ZERO
-    frozen = ZERO
-    entries: list[AccountActivityEntry] = []
+async def get_my_activity(
+    user: AuthUser,
+    limit: int = Query(50, ge=1, le=200),
+    before_tx_id: int | None = Query(None, ge=1),
+) -> AccountActivityPage:
+    """Get authenticated user's account activity with cursor pagination."""
+    entries = _build_account_activity(user.account_id)
+    if before_tx_id is not None:
+        entries = [entry for entry in entries if entry.tx_id < before_tx_id]
 
-    for tx in account_txs:
-        available += tx.available_delta
-        frozen += tx.frozen_delta
-        market = app.state.me.markets.get(tx.market_id) if tx.market_id else None
-        outcome = _tx_outcome(tx, market)
-        total_delta = tx.available_delta + tx.frozen_delta
-        entries.append(
-            AccountActivityEntry(
-                tx_id=tx.id,
-                created_at=tx.created_at,
-                summary=_activity_summary(tx, market, outcome),
-                reason=tx.reason,
-                outcome=outcome,
-                available_delta=str(tx.available_delta),
-                frozen_delta=str(tx.frozen_delta),
-                total_delta=str(total_delta),
-                available_after=str(available),
-                frozen_after=str(frozen),
-                total_after=str(available + frozen),
-                market_id=tx.market_id,
-                market_question=market.question if market else None,
-                market_status=market.status if market else None,
-                market_resolution=market.resolution if market else None,
-                trade_id=tx.trade_id,
-                lock_id=tx.lock_id,
-            )
-        )
-
-    entries.reverse()
-    return entries
+    page_entries = entries[:limit]
+    has_more = len(entries) > limit
+    next_before_tx_id = page_entries[-1].tx_id if has_more and page_entries else None
+    return AccountActivityPage(
+        entries=page_entries,
+        has_more=has_more,
+        next_before_tx_id=next_before_tx_id,
+    )
 
 
 @app.post("/v1/markets/{market_id}/buy")

--- a/core/api_models.py
+++ b/core/api_models.py
@@ -61,6 +61,11 @@ class AccountActivityEntry(BaseModel):
     trade_id: int | None = None
     lock_id: int | None = None
 
+class AccountActivityPage(BaseModel):
+    entries: list[AccountActivityEntry]
+    has_more: bool
+    next_before_tx_id: int | None = None
+
 
 # --- Markets ---
 

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -380,7 +380,10 @@ class TestAccountActivity:
 
         resp = await client.get("/v1/me/activity", headers=headers)
         assert resp.status_code == 200
-        activity = resp.json()
+        payload = resp.json()
+        activity = payload["entries"]
+        assert payload["has_more"] is False
+        assert payload["next_before_tx_id"] is None
         assert len(activity) >= 5
 
         assert activity[0]["market_id"] == loss_mid
@@ -405,6 +408,43 @@ class TestAccountActivity:
         assert Decimal(buy_entry["available_delta"]) < 0
         assert Decimal(buy_entry["frozen_delta"]) > 0
         assert Decimal(buy_entry["total_delta"]) == Decimal("0")
+
+    async def test_activity_paginates_with_before_tx_id_cursor(self, client):
+        resp = await client.post("/v1/admin/markets", headers=ADMIN_HEADERS,
+                                 json={"question": "Paginate?", "category": "t",
+                                       "category_id": "t#page"})
+        assert resp.status_code == 200
+        mid = resp.json()["market_id"]
+
+        key = await _mock_auth(client, github_id=55, login="pager")
+        headers = _user_headers(key)
+
+        for _ in range(3):
+            resp = await client.post(f"/v1/markets/{mid}/buy", headers=headers,
+                                     json={"outcome": "yes", "budget": "10"})
+            assert resp.status_code == 200
+
+        resp = await client.get("/v1/me/activity", headers=headers,
+                                params={"limit": 2})
+        assert resp.status_code == 200
+        first_page = resp.json()
+
+        assert len(first_page["entries"]) == 2
+        assert first_page["has_more"] is True
+        assert first_page["next_before_tx_id"] == first_page["entries"][-1]["tx_id"]
+        assert first_page["entries"][0]["tx_id"] > first_page["entries"][1]["tx_id"]
+
+        resp = await client.get("/v1/me/activity", headers=headers,
+                                params={"limit": 2,
+                                        "before_tx_id": first_page["next_before_tx_id"]})
+        assert resp.status_code == 200
+        second_page = resp.json()
+
+        assert len(second_page["entries"]) == 2
+        assert second_page["entries"][0]["tx_id"] < first_page["entries"][-1]["tx_id"]
+        assert second_page["entries"][0]["tx_id"] > second_page["entries"][1]["tx_id"]
+        assert second_page["has_more"] is False
+        assert second_page["next_before_tx_id"] is None
 
 # ---------------------------------------------------------------------------
 # Public Market Data

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -198,6 +198,9 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
 .delta.neg { color: #f85149; }
 .delta.flat { color: #8b949e; }
 .balance-after { font-family: 'SF Mono', monospace; font-size: 13px; }
+.activity-more-btn { margin-top: 12px; padding: 8px 14px; border-radius: 6px; border: 1px solid #30363d; background: transparent; color: #e6edf3; cursor: pointer; font-size: 13px; }
+.activity-more-btn:hover:not(:disabled) { border-color: #58a6ff; color: #58a6ff; }
+.activity-more-btn:disabled { opacity: 0.6; cursor: wait; }
 </style>
 </head>
 <body>
@@ -217,9 +220,13 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
   const authBar = document.getElementById('auth-bar');
   const githubLoginBaseUrl = '/v1/auth/github/login';
   const accountPickerKey = 'futarchy_force_account_picker';
+  const ACTIVITY_PAGE_SIZE = 20;
   let pollTimer = null;
   let currentFilter = 'open';
   let currentRepoFilter = sessionStorage.getItem('futarchy_repo_filter') || 'all';
+  let activityEntries = [];
+  let activityHasMore = false;
+  let activityNextBeforeTxId = null;
 
   // --- Auth state ---
   function getAuth() {
@@ -427,6 +434,46 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
       }).join('')}
     </table>`;
   }
+  function renderActivitySection() {
+    return `
+      <div class="section-title" style="margin-top:24px">Activity</div>
+      <div class="activity-help">Showing latest ${activityEntries.length}${activityHasMore ? '+' : ''} entries. Buys move credits from available to frozen. Total only changes when you sell, a market resolves, or a market is voided.</div>
+      ${activityEntries.length === 0 ? '<div class="empty">No account activity yet.</div>' : renderActivityTable(activityEntries)}
+      ${activityHasMore ? '<button id="activity-more-btn" class="activity-more-btn">Load older activity</button>' : ''}
+    `;
+  }
+  function bindActivityControls() {
+    const btn = document.getElementById('activity-more-btn');
+    if (!btn) return;
+    btn.onclick = loadMoreActivity;
+  }
+  async function loadMoreActivity() {
+    if (!activityHasMore || !activityNextBeforeTxId) return;
+    const btn = document.getElementById('activity-more-btn');
+    if (!btn) return;
+    btn.disabled = true;
+    btn.textContent = 'Loading...';
+    try {
+      const page = await apiAuth('/me/activity?limit=' + ACTIVITY_PAGE_SIZE + '&before_tx_id=' + activityNextBeforeTxId);
+      activityEntries = activityEntries.concat(page.entries || []);
+      activityHasMore = !!page.has_more;
+      activityNextBeforeTxId = page.next_before_tx_id || null;
+      const panel = document.getElementById('activity-panel');
+      if (panel) {
+        panel.innerHTML = renderActivitySection();
+        bindActivityControls();
+      }
+    } catch (e) {
+      if (e.status === 401) {
+        clearAuth();
+        renderAuthBar();
+        location.hash = '#/auth';
+        return;
+      }
+      btn.disabled = false;
+      btn.textContent = 'Retry loading older activity';
+    }
+  }
 
   // --- LMSR helpers (lightweight, for labels + estimates) ---
 
@@ -585,11 +632,14 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
     if (!area) return;
 
     try {
-      const [me, activity, allMarkets] = await Promise.all([
+      const [me, activityPage, allMarkets] = await Promise.all([
         apiAuth('/me'),
-        apiAuth('/me/activity'),
+        apiAuth('/me/activity?limit=' + ACTIVITY_PAGE_SIZE),
         api('/markets'),
       ]);
+      activityEntries = activityPage.entries || [];
+      activityHasMore = !!activityPage.has_more;
+      activityNextBeforeTxId = activityPage.next_before_tx_id || null;
 
       // Find positions for this account across all markets
       const accountId = parseInt(auth.accountId);
@@ -659,9 +709,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
           }).join('')
         }
 
-        <div class="section-title" style="margin-top:24px">Activity (${activity.length})</div>
-        <div class="activity-help">Buys move credits from available to frozen. Total only changes when you sell, a market resolves, or a market is voided.</div>
-        ${activity.length === 0 ? '<div class="empty">No account activity yet.</div>' : renderActivityTable(activity)}
+        <div id="activity-panel">${renderActivitySection()}</div>
 
         ${me.locks && me.locks.length > 0 ? `
           <div class="section-title" style="margin-top:24px">Active Locks (${me.locks.length})</div>
@@ -676,6 +724,7 @@ details.lmsr-ref .ref-content p { margin: 4px 0; }
           </table>
         ` : ''}
       `;
+      bindActivityControls();
     } catch (e) {
       if (e.status === 401) {
         clearAuth();


### PR DESCRIPTION
## Summary
- add paginated account activity to the authenticated API
- show account history in both the dashboard and the CLI
- make balances clearer by showing total, available, and frozen separately

## Why
Users can currently lose track of where credits went because the product only shows current balances and positions. There is no readable account history, and the dashboard previously emphasized available balance in a way that made normal position locking look like missing money.

## What changed
- `/v1/me/activity` now returns a paginated activity page with `entries`, `has_more`, and `next_before_tx_id`
- the dashboard portfolio view loads the newest activity first and supports loading older entries
- the CLI now has `futarchy activity --limit ... --before-tx-id ...`
- `futarchy me` points users to the activity command for history

## Validation
- `python3 -m py_compile core/api.py core/api_models.py core/test_api.py cli/futarchy_cli/api.py cli/futarchy_cli/main.py cli/futarchy_cli/fmt.py`
- `pytest -q core/test_api.py`
- dashboard JS parse check via `node`
- CLI help check: `python3 -m futarchy_cli.main activity --help`
