### PR TITLE
Q4 vision brainstorm: issue markets, trust layer, agent reputation

### DIFF
--- a/docs/brainstorm/00-INDEX.md
+++ b/docs/brainstorm/00-INDEX.md
@@ -17,6 +17,14 @@ Detailed thinking on each idea. These are explorations, not specs. Some of this 
 ## MVP Design
 
 - `12-mvp-design.md` — Conditional prediction markets on PRs. LMSR AMMs, risk engine / market engine separation, data models, implementation plan.
+- `17-mvp-status-2026-03-17.md` — **MVP shipped.** What's live, architecture decisions made, lessons learned.
+
+## Beyond PRs (Q4 Vision — 2026-03-17)
+
+- `13-issue-resolution-markets.md` — Markets where agents bet on issues and then solve them. Prediction + action linked. Compound markets (issue → PR → quality).
+- `14-market-types-beyond-prs.md` — Full taxonomy: issue resolution, repo adoption, CI stability, skill safety, governance. Four business hypotheses and how to test them.
+- `15-trust-layer-for-ai.md` — Prediction markets as a trust/safety layer for AI skills and agents. Bug bounties through markets. The decentralized social credit score, for AIs first.
+- `16-agent-reputation-exchange.md` — Portable agent reputation from prediction market track records. The feedback loop: trade → accuracy → trust → opportunity → trade.
 
 ## Architecture Thinking
 
@@ -32,5 +40,8 @@ These are directions we're leaning toward, not final decisions:
 - Supply and demand pricing, not fixed rates
 - Escalation game with trusted authority as backstop for reviews
 - Run full autonomy on our own repo first
+- **Issue resolution markets** as the next market type (objective resolution, actionable)
+- **Trust layer for AI** as the most timely business opportunity
+- **Agent reputation** as the long-term moat
 
-*Last updated: 2026-02-23*
+*Last updated: 2026-03-17*

--- a/docs/brainstorm/13-issue-resolution-markets.md
+++ b/docs/brainstorm/13-issue-resolution-markets.md
@@ -1,0 +1,81 @@
+# Issue Resolution Markets
+
+*Brainstorm: 2026-03-17. Extends [04-reviewer-mechanism.md](04-reviewer-mechanism.md).*
+
+## The Insight
+
+PR merge markets are passive — you're predicting someone else's decision. Issue resolution markets are **actionable** — an agent can bet YES and then go solve the issue. The prediction and the action are linked. This is skin in the game.
+
+## How It Works
+
+1. An issue exists on a public repo (e.g., `openclaw/openclaw#12345`)
+2. A market opens: "Will this issue be closed-as-completed within 30 days?"
+3. Agents trade based on their assessment of difficulty, priority, available resources
+4. An agent bets YES → submits a PR that fixes the issue
+5. Issue closes with a merged PR → market resolves YES → agent profits
+
+The bet is both a forecast AND a commitment.
+
+## Resolution Rules
+
+- **YES**: Issue is closed with a linked merged PR (GitHub automatically links PRs that reference issues)
+- **NO**: Issue is closed as `not_planned`, `wontfix`, or `duplicate`
+- **VOID**: Issue still open at deadline (same as PR markets — no penalty for inaction)
+
+Void-on-expiry is important. It means agents only risk money when something actually happens. Safe for participation, encourages experimentation.
+
+## Why This Is Better Than Bounties
+
+Traditional bounties (Gitcoin, etc.) have problems:
+- Someone must set the bounty amount (who knows what it's worth?)
+- Payment is all-or-nothing (no signal about partial solutions)
+- No accountability if the fix introduces new bugs
+
+Market-based issue resolution:
+- **Price discovery**: the market price IS the difficulty signal. Low YES price = hard issue. High YES price = someone's about to solve it.
+- **Natural prioritization**: important issues attract more trading volume. Agents who solve high-volume issues earn more reputation.
+- **Compound markets**: once a PR is submitted, a PR quality market can open on top. Two layers of prediction.
+
+## The Compound Play: Issues + PRs + Quality
+
+For a single unit of work, you get a stack:
+
+| Market | Question | Resolution |
+|--------|----------|------------|
+| Issue market | "Will issue #423 be resolved within 30 days?" | GitHub issue state |
+| PR market | "Will PR #891 (the fix) merge?" | GitHub PR state |
+| Quality market | "Will PR #891 cause a regression within 7 days of merge?" | Revert commits, hotfixes, CI failures |
+
+Each layer attracts different agents with different skills:
+- **Issue scouts**: identify solvable issues, bet early
+- **Coders**: write the fix, bet on their own PR
+- **Reviewers**: evaluate the PR, bet on quality
+- **Quality monitors**: track post-merge regressions, bet on stability
+
+## Liquidity and Repo Reputation
+
+Not all issues deserve markets. Liquidity should scale with repo importance:
+
+- Repo stars → base liquidity level
+- Issue labels (e.g., `good-first-issue`, `bug`, `security`) → liquidity multiplier
+- Issue upvotes/reactions → demand signal
+- Historical resolution rate → calibration
+
+This prevents minting infinite credits on obscure repos nobody cares about.
+
+## Connection to Agent Reputation
+
+Every trade is public. Every resolution is objective. Over time, agents build track records:
+- "This agent correctly predicted 80% of issue resolutions on openclaw/openclaw"
+- "This agent solved 12 issues it bet YES on, with 0 regressions"
+- "This agent specializes in security issues and has a 90% accuracy rate"
+
+This is the embryo of the decentralized social credit score — but for AIs first, with objective metrics, on public data.
+
+## Open Questions
+
+- Should issue markets auto-create for all issues, or only labeled/upvoted ones?
+- What's the right deadline? 30 days? Configurable per repo?
+- How to handle issues that are closed and reopened?
+- Should the agent that submits the fix get a bonus beyond market profits?
+- How to prevent gaming (closing issues without actually fixing them)?

--- a/docs/brainstorm/14-market-types-beyond-prs.md
+++ b/docs/brainstorm/14-market-types-beyond-prs.md
@@ -1,0 +1,132 @@
+# Market Types Beyond PRs
+
+*Brainstorm: 2026-03-17. Extends [08-path-to-market.md](08-path-to-market.md).*
+
+PR merge prediction was the starting point — the simplest market with fully automated resolution. But prediction markets can measure anything with an objective outcome. Here's the full landscape of what futarchy.ai could host.
+
+## Taxonomy
+
+### Tier 1: Fully Automated Resolution (ship now)
+
+These resolve from public API data with no human judgment.
+
+**Issue resolution** (see [13-issue-resolution-markets.md](13-issue-resolution-markets.md))
+- "Will issue #X be closed-as-completed within N days?"
+- Resolution: GitHub issue state API
+
+**PR merge** (live today)
+- "Will PR #X merge?" (conditional on closing before deadline)
+- Resolution: GitHub PR state API
+
+**Repo adoption**
+- "Will repo X reach N stars by date Y?"
+- "Will repo X gain >100 stars this month?"
+- Resolution: GitHub API star count
+
+**CI stability**
+- "Will main branch CI stay green for the next 24h?"
+- Resolution: GitHub Actions status API
+
+**Release cadence**
+- "Will repo X cut a release this week?"
+- Resolution: GitHub Releases API
+
+### Tier 2: Automated but Delayed Resolution (ship soon)
+
+These resolve automatically but need a lookback period.
+
+**PR quality / regression**
+- "Will PR #X (if merged) cause a revert within 7 days?"
+- "Will PR #X need a follow-up fix within 14 days?"
+- Resolution: search for revert commits or PRs referencing the original. Automatable but requires post-merge monitoring.
+
+**Dependency risk**
+- "Will upgrading dependency X break the build?"
+- Resolution: CI status after the upgrade lands
+
+**Contributor activity**
+- "Will contributor X have a merged PR this month?"
+- Resolution: GitHub API contributor activity
+
+### Tier 3: Oracle-Assisted Resolution (ship later)
+
+These need some human or AI judgment to resolve.
+
+**Skill/tool safety** (the trust layer)
+- "Will this ClawHub skill have a reported vulnerability within 90 days?"
+- Resolution: security advisory, CVE, exploit report. Needs a submission + verification process.
+
+**Code quality assessment**
+- "Is this PR's code quality above the repo's median?"
+- Resolution: structured review rubric + trusted reviewer (could be escalation game from [04-reviewer-mechanism.md](04-reviewer-mechanism.md))
+
+**Feature success**
+- "Will this feature increase weekly active users by >5%?"
+- Resolution: analytics data. Needs a trusted data source or on-chain proof.
+
+### Tier 4: Governance / Futarchy (the endgame)
+
+Classic futarchy — predict the effect of decisions on metrics.
+
+**DAO proposal outcomes**
+- "If proposal X passes, will the token price be higher in 30 days?"
+- Resolution: on-chain price oracle (Uniswap TWAP, Chainlink)
+- This is what Gnosis/MetaDAO already do. futarchy.ai could be the API layer.
+
+**Organizational decisions**
+- "If we adopt tool X, will our deploy frequency increase?"
+- "If we hire for role Y, will issue resolution rate improve?"
+- Resolution: measurable metrics, configurable per organization
+
+## The Business Hypotheses
+
+Each tier suggests a different business:
+
+### Hypothesis A: Practice Arena for AI Forecasters
+- **Customer**: Developers building AI trading agents for Polymarket, Kalshi, Metaculus
+- **Value prop**: "Train your agent on real markets with automated resolution, no real money at risk"
+- **Moat**: largest set of auto-resolving markets, best API, reference implementations
+- **Revenue**: premium features (historical data, backtesting, higher credit limits)
+- **Why now**: explosion of AI agents targeting prediction markets in 2025-26
+
+### Hypothesis B: PR Triage Signal for Repos
+- **Customer**: Open-source maintainers drowning in PRs
+- **Value prop**: "Add futarchy.ai to your repo — get market-powered triage"
+- **Distribution**: GitHub App, one-click install
+- **Moat**: network effects (more agents → better signals → more repos)
+- **Revenue**: freemium (free for public repos up to N markets, paid for private/enterprise)
+- **Challenge**: need to prove the signal is actually useful (requires good forecasters)
+
+### Hypothesis C: Agent Reputation Exchange
+- **Customer**: Anyone deploying AI agents (coding agents, review agents, DevOps agents)
+- **Value prop**: "Your agent's futarchy.ai track record IS its resume"
+- **Distribution**: agents build reputation by trading, repos check reputation before trusting
+- **Moat**: reputation is sticky — once built, agents don't want to leave
+- **Revenue**: reputation verification API, premium analytics
+- **Connection to vision**: this is the decentralized social credit score, for AIs first
+
+### Hypothesis D: Futarchy-as-a-Service for DAOs
+- **Customer**: Snapshot spaces, Gnosis DAO, any token-governed organization
+- **Value prop**: "Add prediction markets to your governance in one API call"
+- **Distribution**: Snapshot widget integration (already in progress via Q3 work)
+- **Moat**: existing conditional token framework expertise, Gnosis relationship
+- **Revenue**: platform fees on market volume
+- **Challenge**: on-chain markets need real tokens, not credits
+
+## What to Test First
+
+The cheapest way to test all four:
+
+1. **Track OpenClaw** (high activity, many agents) → tests Hypothesis A
+2. **"Add to your repo" flow** (GitHub App) → tests Hypothesis B
+3. **Public leaderboard of agent accuracy** → tests Hypothesis C
+4. **Snapshot widget with conditional markets** → tests Hypothesis D (Q3 connection)
+
+All four can run on the same infrastructure we built today.
+
+## Open Questions
+
+- Which hypothesis has the fastest path to someone paying real money?
+- Can we run all four simultaneously, or do they require different product decisions?
+- When do credits become real tokens? (see [08-path-to-market.md](08-path-to-market.md))
+- How does the "trust layer for AI" angle interact with the competitive landscape (ClawHub, MCP registries, agent marketplaces)?

--- a/docs/brainstorm/15-trust-layer-for-ai.md
+++ b/docs/brainstorm/15-trust-layer-for-ai.md
@@ -1,0 +1,106 @@
+# Trust Layer for AI Agents
+
+*Brainstorm: 2026-03-17.*
+
+## The Problem
+
+The AI agent ecosystem is exploding — ClawHub skills, MCP servers, autonomous coding agents, review bots. The #1 problem: **how do you trust a third-party agent or skill?**
+
+Today's answers are weak:
+- Verified publisher badges (centralized, doesn't catch post-publish changes)
+- Download counts (popularity ≠ safety)
+- Manual audits (don't scale, quickly outdated)
+- User reviews (subjective, gameable)
+
+## The Prediction Market Solution
+
+Instead of trusting a badge or a review, check what the market thinks.
+
+**"Will skill X have a reported vulnerability within 90 days?"**
+
+If the market trades at 5% → high confidence it's safe.
+If the market trades at 40% → something is suspicious, stay away.
+
+The market aggregates information from:
+- Security researchers who audited the code
+- Agents that tested the skill in sandboxes
+- Developers who used it and noticed issues
+- Automated static analysis tools
+
+No single source has the full picture. The market does.
+
+## Why This Creates a Bug Bounty
+
+An agent that finds a vulnerability can:
+1. Buy YES on "will this skill have a vulnerability?"
+2. Report the vulnerability
+3. Market resolves YES → agent profits
+
+The market IS the bug bounty. No bounty program needed. The payout is the market spread. Higher-profile skills attract more liquidity → bigger bounties for finding bugs.
+
+## Market Types for Trust
+
+**Skill safety**
+- "Will skill X have a reported vulnerability within 90 days?"
+- Resolution: security advisory submission + verification process
+
+**Skill reliability**
+- "Will skill X have >99% uptime this month?"
+- Resolution: monitoring data (automated)
+
+**Skill adoption**
+- "Will skill X reach >1000 installs within 60 days?"
+- Resolution: registry stats (automated)
+
+**Agent trustworthiness**
+- "Will agent X complete its next 10 tasks without a failure?"
+- Resolution: task outcome data (automated via taskcore or similar)
+
+**Model quality**
+- "Will model X score above Y on benchmark Z?"
+- Resolution: benchmark results (automated, public)
+
+## The Trust Score
+
+An agent or skill's trust score is derived from its market portfolio:
+- Safety market trading at 95% safe
+- Reliability market at 99%+ uptime
+- 50 resolved markets with no incidents
+
+This composite score is the **prediction-market-derived trust rating**. It's:
+- Dynamic (updates in real time as new info emerges)
+- Incentive-aligned (people who know things are rewarded for sharing)
+- Resistant to gaming (manipulating the market costs real money)
+- Decentralized (no central authority decides who's trusted)
+
+## Connection to the Vision
+
+This is the "decentralized social credit score" from the political vision document — but for AIs first.
+
+Movements have status scores. AIs have trust scores. Both are:
+- Multi-dimensional (safety, reliability, effectiveness, reputation)
+- Maintained by prediction markets
+- Used to decide who gets access, opportunities, resources
+
+Starting with AI trust is strategic because:
+- Resolution is objective (code either has a vulnerability or it doesn't)
+- Participants are agents (faster iteration than humans)
+- The ecosystem needs it NOW (trust is the bottleneck for AI adoption)
+- It proves the mechanism before applying it to human coordination
+
+## Competitive Landscape
+
+- **Socket.dev** — dependency security scanning (static analysis, not market-based)
+- **Snyk** — vulnerability database (centralized, reactive)
+- **ClawHub verification** — publisher badges (centralized trust)
+- **MCP registries** — listing services (no trust signal beyond "it's listed")
+
+None of these use market mechanisms. The market approach is complementary — it aggregates the signals that static tools miss (social engineering, supply chain attacks, subtle backdoors that pass automated checks).
+
+## Open Questions
+
+- Who submits vulnerability reports? Open to anyone, or credentialed researchers?
+- How to prevent false reports (griefing)? Require a bond? Escalation game?
+- How to bootstrap liquidity on skill markets? (Most skills are obscure)
+- Can the trust score be composable across registries?
+- Should trust markets be free (public good) or paid (business model)?

--- a/docs/brainstorm/16-agent-reputation-exchange.md
+++ b/docs/brainstorm/16-agent-reputation-exchange.md
@@ -1,0 +1,97 @@
+# Agent Reputation Exchange
+
+*Brainstorm: 2026-03-17. Connects [03-agent-economy.md](03-agent-economy.md), [07-counterfactual-eval.md](07-counterfactual-eval.md), and the decentralized social credit score vision.*
+
+## The Idea
+
+Every trade on futarchy.ai is public. Every resolution is objective. Over time, agents build track records that serve as portable reputation.
+
+An agent's futarchy.ai profile shows:
+- Total markets traded
+- Accuracy rate (predictions that resolved correctly)
+- Profit/loss (net credits earned)
+- Specialization (which repos, which market types)
+- History (every trade, timestamped, verifiable)
+
+This track record IS the agent's resume.
+
+## Why Reputation Matters for Agents
+
+Agents are increasingly autonomous — they write code, review PRs, manage infrastructure, interact with users. The question every system asks: **should I trust this agent?**
+
+Today, trust is binary: either the agent's operator configured it, or it's not allowed. There's no gradient, no earned trust, no track record.
+
+With a prediction market track record:
+- A repo can say "only allow PRs from agents with >70% accuracy on futarchy.ai"
+- A task system can prioritize agents with proven track records
+- An agent marketplace can rank agents by their prediction market performance
+- A DAO can weight votes by prediction accuracy (epistocracy through markets)
+
+## The Feedback Loop
+
+1. Agent trades on futarchy.ai markets → builds track record
+2. Track record gives agent access to more opportunities (repos, tasks, trust)
+3. More opportunities → more markets to trade on → better track record
+4. Reputation compounds
+
+This is the same flywheel that makes credit scores powerful in traditional finance — but transparent, objective, and decentralized.
+
+## Reputation Dimensions
+
+Not all accuracy is equal. An agent might be:
+- Great at predicting PR merges on JavaScript repos, terrible on Rust repos
+- Accurate on issue resolution timing, wrong on PR quality
+- Profitable on high-liquidity markets, losing on thin ones
+
+The reputation system should capture these dimensions:
+
+| Dimension | What it measures | Signal |
+|-----------|-----------------|--------|
+| Accuracy | Predictions that resolved correctly | Win rate per market type |
+| Calibration | How close predictions were to actual outcomes | Brier score |
+| Profitability | Net credits earned | P&L over time |
+| Specialization | Domain expertise | Accuracy by repo / language / market type |
+| Consistency | Reliability over time | Variance, drawdown |
+| Volume | Skin in the game | Total credits wagered |
+
+## Connection to Agent Economy
+
+In [03-agent-economy.md](03-agent-economy.md), agents earn and spend credits through work. Reputation adds a second dimension: agents earn **trust** through prediction accuracy.
+
+The two reinforce each other:
+- Credits = what you can spend (purchasing power)
+- Reputation = what you can access (trust, opportunity)
+
+An agent with high reputation but low credits can borrow against its reputation (credit markets!).
+An agent with high credits but low reputation can buy reputation by making good predictions.
+
+## The Leaderboard
+
+The simplest implementation: a public leaderboard on futarchy.ai showing:
+- Top agents by accuracy
+- Top agents by profit
+- Top agents by volume
+- Filtering by repo, market type, time period
+
+This is the minimum viable reputation system. It already provides:
+- Social proof (Fabien can see which agents are good)
+- Competition (agents try to top the leaderboard)
+- Discovery (repo owners find reliable agents)
+
+## From AI Reputation to Human Reputation
+
+If the mechanism works for AIs — objective markets, transparent track records, multi-dimensional scoring — it can extend to humans:
+
+- Contributors build reputation by predicting issue resolutions on repos they know
+- Reviewers build reputation by predicting PR quality
+- Forecasters build reputation across domains
+
+And from there to the full vision: movements, organizations, countries — each with their own score, their own metrics, their own futarchy. But it starts with agents, because agents iterate faster and resolution is cleaner.
+
+## Open Questions
+
+- Is the leaderboard enough, or do we need a structured reputation API?
+- How to handle Sybil attacks (one operator creating many agents to game reputation)?
+- Should reputation decay over time (recent accuracy matters more)?
+- Can reputation be staked? (Agent bets its reputation on a prediction)
+- How does agent reputation interact with the trust layer for skills?

--- a/docs/brainstorm/17-mvp-status-2026-03-17.md
+++ b/docs/brainstorm/17-mvp-status-2026-03-17.md
@@ -1,0 +1,45 @@
+# MVP Status — 2026-03-17
+
+What we shipped today and what it means.
+
+## What's Live
+
+- **Dashboard**: [futarchy.ai](https://futarchy.ai) — served from Netlify CDN, API proxy to `api.futarchy.ai`
+- **API**: `api.futarchy.ai/v1/` — FastAPI, LMSR AMM, credit-based prediction markets
+- **Markets**: 70+ markets across 4 repos (snapshot-labs/sx-monorepo, futarchy-fi/agents, futarchy-fi/taskcore, futarchy-fi/interface)
+- **Auth**: GitHub OAuth (web flow, one-click "Sign in with GitHub")
+- **Trading**: buy/sell YES/NO on any open market, portfolio view
+- **Forecaster**: `naive-bayes` agent trading hourly with LMSR-aware Kelly sizing
+- **Rollover**: daily cron voids expired markets, creates new ones for open PRs
+- **Resolution**: automatic — merged PRs → YES, closed without merge → NO, deadline expired → VOID
+
+## Architecture Decisions Made
+
+**Exchange logic vs. exchange data**: Code is version-controlled (the repo). Data (trades, balances, positions) is NOT in git. The repo improves itself through PRs — prediction markets on those PRs are the governance mechanism.
+
+**Deploy is CI-driven**: Push to main → webhook → deploy. No regular server access needed. Server-side crons (rollover, forecaster) are installed by `post-deploy.sh` on first deploy.
+
+**Append-only ledger**: Every state mutation (trade, mint, status override) creates a Transaction entry. Account balances are materialized views. The ledger is the source of truth. This maps to on-chain contracts in the future.
+
+**LMSR-aware Kelly sizing**: The forecaster doesn't use naive Kelly (which ignores price impact). It maximizes expected log utility over the LMSR cost surface — binary search for the optimal trade size that accounts for liquidity depth.
+
+**Virtual bankroll**: The forecaster's position sizing is controlled by a virtual bankroll (1000 credits) independent of its actual balance (10000 credits). This gives a tunable aggressiveness knob without risking the full account.
+
+## What We Learned
+
+1. **Deployment was NOT the main blocker** — the slot-20 agent's report was right. The core engine was built and deployed months ago. Product correctness and usable UX were the real gaps.
+
+2. **GitHub Actions is fragile for critical infrastructure** — the `krandder` account got Actions disabled (free tier limit), breaking all market lifecycle crons. Server-side crons are more reliable.
+
+3. **Per-repo conditional merge rates vary wildly** — snapshot-labs/sx-monorepo: 93% (internal team). openclaw/openclaw: 16% (open source with many drive-by PRs). The forecaster MUST use per-repo base rates.
+
+4. **The JSON snapshot persistence won't scale** — every mutation writes the full state. Fine for 70 markets, breaks at 10,000. Need incremental persistence (database or append-only log) before tracking high-volume repos like OpenClaw.
+
+## Next Steps (Business Hypotheses to Test)
+
+See [14-market-types-beyond-prs.md](14-market-types-beyond-prs.md) for the full analysis. Summary:
+
+- **Issue resolution markets** — agents bet on whether issues will be solved, then solve them. Prediction + action linked.
+- **Trust layer for AI** — prediction markets on skill/agent safety. The ecosystem needs this now.
+- **Agent reputation exchange** — public track records from market performance. Portable trust.
+- **Futarchy-as-a-service for DAOs** — Snapshot widget integration (connects to Gnosis work).


### PR DESCRIPTION
## Summary
Five new brainstorm documents from today's coaching session exploring where futarchy.ai goes after PR prediction markets.

## New docs
- **13-issue-resolution-markets.md** — Markets where prediction and action are linked. Agents bet YES on issues then solve them. Compound markets (issue → PR → quality).
- **14-market-types-beyond-prs.md** — Full taxonomy of market types (Tier 1-4 by resolution difficulty). Four business hypotheses: practice arena, PR triage, agent reputation, futarchy-as-a-service.
- **15-trust-layer-for-ai.md** — Prediction markets as a trust/safety layer for the AI skill ecosystem. Bug bounties through markets.
- **16-agent-reputation-exchange.md** — Portable agent reputation built from prediction market track records. Multi-dimensional (accuracy, calibration, specialization).
- **17-mvp-status-2026-03-17.md** — Snapshot of what shipped today, architecture decisions, lessons.