### PR TITLE
Fix CLI buy/sell payload types

### DIFF
--- a/cli/futarchy_cli/api.py
+++ b/cli/futarchy_cli/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from decimal import Decimal
 
 import httpx
 
@@ -78,14 +79,16 @@ class Client:
 
     # ── Trading endpoints ──
 
-    def buy(self, market_id: int, outcome: str, budget: float) -> dict:
+    def buy(self, market_id: int, outcome: str,
+            budget: str | Decimal | int | float) -> dict:
         return self.post(f"/v1/markets/{market_id}/buy", body={
             "outcome": outcome,
-            "budget": budget,
+            "budget": str(budget),
         })
 
-    def sell(self, market_id: int, outcome: str, amount: float) -> dict:
+    def sell(self, market_id: int, outcome: str,
+             amount: str | Decimal | int | float) -> dict:
         return self.post(f"/v1/markets/{market_id}/sell", body={
             "outcome": outcome,
-            "amount": amount,
+            "amount": str(amount),
         })

--- a/cli/futarchy_cli/main.py
+++ b/cli/futarchy_cli/main.py
@@ -7,6 +7,7 @@ import json
 import shutil
 import subprocess
 import sys
+from decimal import Decimal
 
 from . import __version__
 from . import api as api_mod
@@ -176,13 +177,13 @@ def main(argv: list[str] | None = None) -> int:
     p_buy = _sub(sub, "buy", help="Buy outcome tokens")
     p_buy.add_argument("market_id", type=int, help="Market ID")
     p_buy.add_argument("outcome", choices=["yes", "no"], help="Outcome to buy")
-    p_buy.add_argument("budget", type=float, help="Amount to spend")
+    p_buy.add_argument("budget", type=Decimal, help="Amount to spend")
 
     # futarchy sell <id> <outcome> <amount>
     p_sell = _sub(sub, "sell", help="Sell outcome tokens")
     p_sell.add_argument("market_id", type=int, help="Market ID")
     p_sell.add_argument("outcome", choices=["yes", "no"], help="Outcome to sell")
-    p_sell.add_argument("amount", type=float, help="Number of tokens to sell")
+    p_sell.add_argument("amount", type=Decimal, help="Number of tokens to sell")
 
     args = parser.parse_args(argv)
 

--- a/core/test_cli_compat.py
+++ b/core/test_cli_compat.py
@@ -1,0 +1,46 @@
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+from core.api_models import BuyRequest, SellRequest
+
+
+CLI_ROOT = Path(__file__).resolve().parents[1] / "cli"
+if str(CLI_ROOT) not in sys.path:
+    sys.path.insert(0, str(CLI_ROOT))
+
+from futarchy_cli.api import Client
+
+
+class _CaptureClient(Client):
+    def __init__(self):
+        super().__init__(api_url="http://test")
+        self.captured = None
+
+    def post(self, path: str, body: dict) -> dict:
+        self.captured = {"path": path, "body": body}
+        return body
+
+
+def test_cli_buy_serializes_budget_as_string_matching_api_model():
+    client = _CaptureClient()
+    payload = client.buy(45, "no", Decimal("1.25"))
+
+    assert client.captured == {
+        "path": "/v1/markets/45/buy",
+        "body": {"outcome": "no", "budget": "1.25"},
+    }
+    assert BuyRequest(**payload).budget == "1.25"
+    client._http.close()
+
+
+def test_cli_sell_serializes_amount_as_string_matching_api_model():
+    client = _CaptureClient()
+    payload = client.sell(45, "yes", Decimal("2.5"))
+
+    assert client.captured == {
+        "path": "/v1/markets/45/sell",
+        "body": {"outcome": "yes", "amount": "2.5"},
+    }
+    assert SellRequest(**payload).amount == "2.5"
+    client._http.close()


### PR DESCRIPTION
## Summary
- serialize CLI `buy` budgets and `sell` amounts as strings to match the live API schema
- stop parsing these values as `float` in the CLI entrypoint
- add a compatibility regression test that validates CLI payloads against the API request models

## Why
Issue #35 is only partially resolved on `main`: `futarchy activity` already exists, but `futarchy buy` and `futarchy sell` still post numeric JSON values while the live API expects strings.

## Validation
- `python3 -m py_compile cli/futarchy_cli/api.py cli/futarchy_cli/main.py core/test_cli_compat.py`
- `pytest -q core/test_cli_compat.py core/test_api.py`
- `python3 -m futarchy_cli.main buy --help`
- `python3 -m futarchy_cli.main sell --help`
