### PR TITLE
Add CLI stale-version warnings

### DIFF
--- a/cli/futarchy_cli/api.py
+++ b/cli/futarchy_cli/api.py
@@ -19,12 +19,14 @@ class APIError(Exception):
 
 
 class Client:
-    def __init__(self, api_url: str = DEFAULT_API_URL, api_key: str | None = None):
+    def __init__(self, api_url: str = DEFAULT_API_URL,
+                 api_key: str | None = None,
+                 timeout: float = TIMEOUT):
         self.base = api_url.rstrip("/")
         headers = {"Accept": "application/json"}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
-        self._http = httpx.Client(base_url=self.base, headers=headers, timeout=TIMEOUT)
+        self._http = httpx.Client(base_url=self.base, headers=headers, timeout=timeout)
 
     def _request(self, method: str, path: str, **kwargs) -> dict | list:
         try:
@@ -69,12 +71,18 @@ class Client:
     def me(self) -> dict:
         return self.get("/v1/me")
 
+    def cli_version(self) -> dict:
+        return self.get("/v1/cli/version")
+
     def activity(self, limit: int = 20,
                  before_tx_id: int | None = None) -> dict:
         params = {"limit": limit}
         if before_tx_id is not None:
             params["before_tx_id"] = before_tx_id
         return self.get("/v1/me/activity", **params)
+
+    def close(self) -> None:
+        self._http.close()
 
     # ── Trading endpoints ──
 

--- a/cli/futarchy_cli/main.py
+++ b/cli/futarchy_cli/main.py
@@ -12,6 +12,7 @@ from . import __version__
 from . import api as api_mod
 from . import auth
 from . import fmt
+from .update_check import maybe_warn_about_update
 
 
 def _add_global_args(parser: argparse.ArgumentParser) -> None:
@@ -189,6 +190,10 @@ def main(argv: list[str] | None = None) -> int:
     if not args.command:
         parser.print_help()
         return 0
+
+    if args.command != "update":
+        maybe_warn_about_update(args.api_url or auth.get_api_url(),
+                                json_output=args.json_output)
 
     dispatch = {
         "markets": cmd_markets,

--- a/cli/futarchy_cli/update_check.py
+++ b/cli/futarchy_cli/update_check.py
@@ -1,0 +1,110 @@
+"""Lightweight remote CLI version checks with a local cache."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from . import __version__
+from . import api as api_mod
+
+
+CACHE_DIR = Path.home() / ".cache" / "futarchy"
+CACHE_FILE = CACHE_DIR / "version-check.json"
+CACHE_TTL_SECONDS = 24 * 60 * 60
+WARN_TTL_SECONDS = 24 * 60 * 60
+
+
+def _parse_version(version: str) -> tuple[int, ...] | None:
+    parts = version.split(".")
+    try:
+        return tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+
+
+def _is_newer(version: str | None, current: str) -> bool:
+    if not version:
+        return False
+    parsed = _parse_version(version)
+    current_parsed = _parse_version(current)
+    if parsed is None or current_parsed is None:
+        return False
+    return parsed > current_parsed
+
+
+def _load_cache() -> dict:
+    if not CACHE_FILE.exists():
+        return {}
+    try:
+        return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_cache(data: dict) -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _fetch_remote_version(api_url: str) -> dict | None:
+    client = api_mod.Client(api_url=api_url, timeout=1.5)
+    try:
+        return client.cli_version()
+    except Exception:
+        return None
+    finally:
+        client.close()
+
+
+def maybe_warn_about_update(api_url: str, json_output: bool = False) -> None:
+    cache = _load_cache()
+    now = int(time.time())
+
+    should_refresh = (
+        "latest_version" not in cache or
+        now - int(cache.get("checked_at", 0)) >= CACHE_TTL_SECONDS
+    )
+    if should_refresh:
+        latest = _fetch_remote_version(api_url)
+        if latest:
+            cache["checked_at"] = now
+            cache["latest_version"] = latest.get("latest_version")
+            cache["minimum_supported_version"] = latest.get(
+                "minimum_supported_version"
+            )
+            cache["update_command"] = latest.get("update_command", "futarchy update")
+            _save_cache(cache)
+
+    if json_output:
+        return
+
+    latest_version = cache.get("latest_version")
+    minimum_supported_version = cache.get("minimum_supported_version")
+    warned_version = cache.get("warned_version")
+    warned_at = int(cache.get("warned_at", 0))
+
+    if minimum_supported_version and _is_newer(minimum_supported_version, __version__):
+        if warned_version != minimum_supported_version or now - warned_at >= WARN_TTL_SECONDS:
+            print(
+                f"Warning: CLI {__version__} is below the minimum supported version "
+                f"{minimum_supported_version}. Run `{cache.get('update_command', 'futarchy update')}`.",
+                file=sys.stderr,
+            )
+            cache["warned_version"] = minimum_supported_version
+            cache["warned_at"] = now
+            _save_cache(cache)
+        return
+
+    if latest_version and _is_newer(latest_version, __version__):
+        if warned_version != latest_version or now - warned_at >= WARN_TTL_SECONDS:
+            print(
+                f"Notice: CLI {__version__} is out of date; latest is {latest_version}. "
+                f"Run `{cache.get('update_command', 'futarchy update')}`.",
+                file=sys.stderr,
+            )
+            cache["warned_version"] = latest_version
+            cache["warned_at"] = now
+            _save_cache(cache)

--- a/core/api.py
+++ b/core/api.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone, timedelta
@@ -28,6 +29,7 @@ from core.api_models import (
     AuthResponse,
     DeviceFlowStartRequest, DeviceFlowResponse, DeviceFlowPollRequest,
     AccountResponse, AccountActivityEntry, AccountActivityPage, LockResponse,
+    CliVersionResponse,
     MarketSummary, MarketDetail, PositionEntry, TradeResponse,
     DepthEntry, DepthResponse,
     BuyRequest, SellRequest, TradeResult,
@@ -58,6 +60,7 @@ STATE_PATH = os.environ.get("FUTARCHY_STATE", "./futarchy_state.json")
 INITIAL_CREDITS = Decimal(os.environ.get("INITIAL_CREDITS", "100"))
 GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
 GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
+MIN_SUPPORTED_CLI_VERSION = os.environ.get("FUTARCHY_MIN_SUPPORTED_CLI_VERSION") or None
 TREASURY_ACCOUNT_ID = os.environ.get("FUTARCHY_TREASURY_ID", "")
 GITHUB_OAUTH_REDIRECT_URI = os.environ.get(
     "GITHUB_OAUTH_REDIRECT_URI",
@@ -78,6 +81,24 @@ LIQUIDITY_BUDGET = os.environ.get("LIQUIDITY_BUDGET", "200")
 MARKET_EXPIRY_CHECK_INTERVAL_SECONDS = float(
     os.environ.get("MARKET_EXPIRY_CHECK_INTERVAL_SECONDS", "60")
 )
+CLI_INIT_PATH = Path(__file__).resolve().parents[1] / "cli" / "futarchy_cli" / "__init__.py"
+
+
+def _read_cli_version() -> str:
+    try:
+        text = CLI_INIT_PATH.read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("Unable to read CLI version from %s", CLI_INIT_PATH)
+        return "0.0.0"
+
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    if not match:
+        logger.warning("Unable to parse CLI version from %s", CLI_INIT_PATH)
+        return "0.0.0"
+    return match.group(1)
+
+
+LATEST_CLI_VERSION = _read_cli_version()
 
 
 @asynccontextmanager
@@ -408,6 +429,16 @@ async def health() -> HealthResponse:
             len(auth_store.users) +
             len(getattr(auth_store, "local_users", {}))
         ),
+    )
+
+
+@app.get("/v1/cli/version")
+async def cli_version() -> CliVersionResponse:
+    """Get the latest published CLI version for update checks."""
+    return CliVersionResponse(
+        latest_version=LATEST_CLI_VERSION,
+        minimum_supported_version=MIN_SUPPORTED_CLI_VERSION,
+        update_command="futarchy update",
     )
 
 

--- a/core/api_models.py
+++ b/core/api_models.py
@@ -66,6 +66,11 @@ class AccountActivityPage(BaseModel):
     has_more: bool
     next_before_tx_id: int | None = None
 
+class CliVersionResponse(BaseModel):
+    latest_version: str
+    minimum_supported_version: str | None = None
+    update_command: str
+
 
 # --- Markets ---
 
@@ -195,6 +200,12 @@ class HealthResponse(BaseModel):
     markets: int
     ledger_accounts: int
     users: int
+
+
+class CliVersionResponse(BaseModel):
+    latest_version: str
+    minimum_supported_version: str | None = None
+    update_command: str
 
 
 # --- Tracked Repos ---

--- a/core/test_api.py
+++ b/core/test_api.py
@@ -114,6 +114,14 @@ class TestHealth:
         assert data["ledger_accounts"] == 3
         assert data["users"] == 2
 
+    async def test_cli_version_manifest(self, client):
+        resp = await client.get("/v1/cli/version")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["update_command"] == "futarchy update"
+        assert data["latest_version"]
+        assert data["minimum_supported_version"] is None
+
 
 # ---------------------------------------------------------------------------
 # Auth

--- a/core/test_cli_update_check.py
+++ b/core/test_cli_update_check.py
@@ -1,0 +1,88 @@
+import json
+import sys
+from pathlib import Path
+
+
+CLI_ROOT = Path(__file__).resolve().parents[1] / "cli"
+if str(CLI_ROOT) not in sys.path:
+    sys.path.insert(0, str(CLI_ROOT))
+
+from futarchy_cli import update_check
+
+
+class _FakeClient:
+    def __init__(self, api_url: str, timeout: float):
+        self.api_url = api_url
+        self.timeout = timeout
+
+    def cli_version(self) -> dict:
+        return {
+            "latest_version": "0.9.9",
+            "minimum_supported_version": None,
+            "update_command": "futarchy update",
+        }
+
+    def close(self) -> None:
+        pass
+
+
+def test_update_check_warns_and_caches_latest_version(tmp_path, monkeypatch, capsys):
+    cache_file = tmp_path / "version-check.json"
+    monkeypatch.setattr(update_check, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(update_check, "CACHE_FILE", cache_file)
+    monkeypatch.setattr(update_check, "__version__", "0.1.2")
+    monkeypatch.setattr(update_check.api_mod, "Client", _FakeClient)
+    monkeypatch.setattr(update_check.time, "time", lambda: 1_000)
+
+    update_check.maybe_warn_about_update("https://api.example.com")
+
+    stderr = capsys.readouterr().err
+    assert "out of date" in stderr
+
+    cached = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert cached["latest_version"] == "0.9.9"
+    assert cached["update_command"] == "futarchy update"
+    assert cached["warned_version"] == "0.9.9"
+
+
+def test_update_check_uses_recent_cache_without_network(tmp_path, monkeypatch, capsys):
+    cache_file = tmp_path / "version-check.json"
+    cache_file.write_text(json.dumps({
+        "checked_at": 1_000,
+        "latest_version": "0.9.9",
+        "minimum_supported_version": None,
+        "update_command": "futarchy update",
+    }), encoding="utf-8")
+
+    def _unexpected_client(*args, **kwargs):
+        raise AssertionError("network should not be used for a fresh cache")
+
+    monkeypatch.setattr(update_check, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(update_check, "CACHE_FILE", cache_file)
+    monkeypatch.setattr(update_check, "__version__", "0.1.2")
+    monkeypatch.setattr(update_check.api_mod, "Client", _unexpected_client)
+    monkeypatch.setattr(update_check.time, "time", lambda: 1_100)
+
+    update_check.maybe_warn_about_update("https://api.example.com")
+
+    stderr = capsys.readouterr().err
+    assert "out of date" in stderr
+
+
+def test_update_check_suppresses_warning_for_json_output(tmp_path, monkeypatch, capsys):
+    cache_file = tmp_path / "version-check.json"
+    cache_file.write_text(json.dumps({
+        "checked_at": 1_000,
+        "latest_version": "0.9.9",
+        "minimum_supported_version": None,
+        "update_command": "futarchy update",
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(update_check, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(update_check, "CACHE_FILE", cache_file)
+    monkeypatch.setattr(update_check, "__version__", "0.1.2")
+    monkeypatch.setattr(update_check.time, "time", lambda: 1_100)
+
+    update_check.maybe_warn_about_update("https://api.example.com", json_output=True)
+
+    assert capsys.readouterr().err == ""

--- a/static/install.sh
+++ b/static/install.sh
@@ -131,6 +131,7 @@ if command -v futarchy &>/dev/null; then
     printf "  ${BOLD}futarchy markets${NC}        ${DIM}# browse open markets${NC}\n"
     printf "  ${BOLD}futarchy login${NC}          ${DIM}# create an account${NC}\n"
     printf "  ${BOLD}futarchy buy 1 yes 50${NC}   ${DIM}# trade${NC}\n"
+    printf "  ${BOLD}futarchy update${NC}         ${DIM}# update the CLI later${NC}\n"
 else
     success "futarchy installed!"
     echo ""


### PR DESCRIPTION
## Summary
- publish a public CLI version manifest from the API at `/v1/cli/version`
- add a cached CLI startup check that warns when the installed CLI is stale
- make the installer output mention `futarchy update`

## Why
Users can already upgrade with `futarchy update`, but today the CLI does not tell them when they are behind. That means people only discover they are stale after hitting compatibility bugs.

## Behavior
- the API now reports the latest CLI version and update command
- the CLI checks that endpoint at most once per day and caches the result locally
- interactive CLI runs print a warning to stderr when the installed version is older than the latest published version
- `--json` runs stay quiet to avoid polluting machine-readable output

## Validation
- `python3 -m py_compile core/api.py core/api_models.py core/test_api.py core/test_cli_update_check.py cli/futarchy_cli/api.py cli/futarchy_cli/main.py cli/futarchy_cli/update_check.py`
- `pytest -q core/test_api.py core/test_cli_update_check.py`
- `bash -n static/install.sh`
- `python3 -m futarchy_cli.main update --help`
