### PR TITLE
Sweep AMM balance back to treasury after resolve/void

### DIFF
--- a/core/market_engine.py
+++ b/core/market_engine.py
@@ -170,6 +170,7 @@ class MarketEngine:
 
         from core.models import _now
         market.resolved_at = _now()
+        self._sweep_amm(market)
 
     def void(self, market_id: int) -> None:
         """
@@ -200,6 +201,29 @@ class MarketEngine:
 
         from core.models import _now
         market.resolved_at = _now()
+        self._sweep_amm(market)
+
+    def _sweep_amm(self, market: Market) -> None:
+        """Return the AMM's remaining balance to the original funder.
+
+        After resolve or void, the AMM account may hold leftover credits
+        (the house edge on resolve, or the full liquidity on void).
+        Transfer them back to the account that funded the market so the
+        treasury can reuse the credits for new markets.
+        """
+        funder_id = market.metadata.get("funding_account_id")
+        if funder_id is None:
+            return  # market was funded by minting, nowhere to return
+        funder_id = int(funder_id)
+
+        amm = self.risk.get_account(market.amm_account_id)
+        remainder = amm.available_balance
+        if remainder <= ZERO:
+            return
+
+        self.risk.transfer_available(
+            amm.id, funder_id, remainder,
+            market_id=market.id, reason="amm_sweep")
 
     # ------------------------------------------------------------------
     # Trading


### PR DESCRIPTION
## Summary
After a market resolves or voids, transfer the AMM's remaining available balance back to the account that funded it (treasury).

## Problem
Each market creates a new AMM account funded from the treasury. After void, the 200 credits sat in the dead AMM account forever. After 40 markets, the treasury was empty — rollover crashed.

## Fix
`_sweep_amm()` called at the end of both `resolve()` and `void()`. Transfers AMM's available balance back to `metadata.funding_account_id`. Recorded in the ledger as `amm_sweep`.

## Validation
- 37 core tests pass
- 82 API tests pass